### PR TITLE
build: update Node.js version to 22.x and export app for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "vercel:deploy": "vercel --prod"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": "22.x"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.837.0",

--- a/server.js
+++ b/server.js
@@ -125,7 +125,11 @@ app.get('*', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'index.html'));
 });
 
-app.listen(PORT, () => {
-  console.log(`Server running on http://localhost:${PORT}`);
-  console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
-});
+if (require.main === module) {
+  app.listen(PORT, () => {
+    console.log(`Server running on http://localhost:${PORT}`);
+    console.log(`Environment: ${process.env.NODE_ENV || 'development'}`);
+  });
+}
+
+module.exports = app;


### PR DESCRIPTION
Update the required Node.js engine version from >=18.0.0 to 22.x for compatibility and performance. Also modify server.js to conditionally start the server only when run directly, and export the Express app instance to facilitate testing.