### PR TITLE
feat: multi-bucket support with bucket selector UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,11 +19,18 @@ REFRESH_TOKEN_SECRET=your-super-secret-refresh-token-key-change-this-in-producti
 # API Configuration
 API_KEY=your-api-key-for-external-access-change-this
 
-# Cloudflare API (required for creating buckets via panel)
+# Cloudflare API (required for create/import bucket via panel)
 # Get from: Cloudflare Dashboard → My Profile → API Tokens
 # Token permission: Cloudflare R2 Storage:Edit
 CF_ACCOUNT_ID=your-cloudflare-account-id
 CF_API_TOKEN=your-cloudflare-api-token
+
+# Shared R2 credentials (optional but recommended)
+# Create ONE R2 API Token with access to ALL buckets
+# If set, Import from Cloudflare becomes 1-click (no credentials needed per bucket)
+# Get from: Cloudflare Dashboard → R2 → Manage R2 API Tokens
+R2_SHARED_ACCESS_KEY_ID=your-shared-r2-access-key-id
+R2_SHARED_SECRET_ACCESS_KEY=your-shared-r2-secret-access-key
 
 # Vercel Configuration (automatically set by Vercel)
 # VERCEL_URL=your-project.vercel.app

--- a/.env.example
+++ b/.env.example
@@ -19,5 +19,11 @@ REFRESH_TOKEN_SECRET=your-super-secret-refresh-token-key-change-this-in-producti
 # API Configuration
 API_KEY=your-api-key-for-external-access-change-this
 
+# Cloudflare API (required for creating buckets via panel)
+# Get from: Cloudflare Dashboard → My Profile → API Tokens
+# Token permission: Cloudflare R2 Storage:Edit
+CF_ACCOUNT_ID=your-cloudflare-account-id
+CF_API_TOKEN=your-cloudflare-api-token
+
 # Vercel Configuration (automatically set by Vercel)
 # VERCEL_URL=your-project.vercel.app

--- a/api/bucket-store.js
+++ b/api/bucket-store.js
@@ -78,4 +78,13 @@ function toPublic(bucket) {
   };
 }
 
-module.exports = { listBuckets, getBucketById, addBucket, deleteBucket, toPublic };
+async function updateBucket(id, fields) {
+  const buckets = await readStore();
+  const idx = buckets.findIndex(b => b.id === id);
+  if (idx === -1) return null;
+  buckets[idx] = { ...buckets[idx], ...fields };
+  await writeStore(buckets);
+  return buckets[idx];
+}
+
+module.exports = { listBuckets, getBucketById, addBucket, updateBucket, deleteBucket, toPublic };

--- a/api/bucket-store.js
+++ b/api/bucket-store.js
@@ -1,0 +1,74 @@
+const { master } = require('./r2-client');
+const { v4: uuidv4 } = require('uuid');
+
+const STORE_KEY = 'system/buckets.json';
+const MASTER_BUCKET = () => process.env.R2_BUCKET_NAME;
+
+async function readStore() {
+  try {
+    const result = await master.get({ Bucket: MASTER_BUCKET(), Key: STORE_KEY });
+    const chunks = [];
+    for await (const chunk of result.Body) chunks.push(chunk);
+    return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
+  } catch (err) {
+    // File doesn't exist yet — return empty list
+    if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) return [];
+    throw err;
+  }
+}
+
+async function writeStore(buckets) {
+  await master.put({
+    Bucket: MASTER_BUCKET(),
+    Key: STORE_KEY,
+    Body: JSON.stringify(buckets, null, 2),
+    ContentType: 'application/json',
+  });
+}
+
+async function listBuckets() {
+  return await readStore();
+}
+
+async function getBucketById(id) {
+  const buckets = await readStore();
+  return buckets.find(b => b.id === id) || null;
+}
+
+async function addBucket(data) {
+  const buckets = await readStore();
+  const bucket = {
+    id: uuidv4(),
+    name: data.name,
+    endpoint: data.endpoint,
+    accessKeyId: data.accessKeyId,
+    secretAccessKey: data.secretAccessKey,
+    publicUrl: data.publicUrl || '',
+    createdAt: new Date().toISOString(),
+  };
+  buckets.push(bucket);
+  await writeStore(buckets);
+  return bucket;
+}
+
+async function deleteBucket(id) {
+  const buckets = await readStore();
+  const idx = buckets.findIndex(b => b.id === id);
+  if (idx === -1) return false;
+  buckets.splice(idx, 1);
+  await writeStore(buckets);
+  return true;
+}
+
+// Safe public view — never expose credentials
+function toPublic(bucket) {
+  return {
+    id: bucket.id,
+    name: bucket.name,
+    endpoint: bucket.endpoint,
+    publicUrl: bucket.publicUrl,
+    createdAt: bucket.createdAt,
+  };
+}
+
+module.exports = { listBuckets, getBucketById, addBucket, deleteBucket, toPublic };

--- a/api/bucket-store.js
+++ b/api/bucket-store.js
@@ -12,7 +12,14 @@ async function readStore() {
     return JSON.parse(Buffer.concat(chunks).toString('utf-8'));
   } catch (err) {
     // File doesn't exist yet — return empty list
-    if (err.name === 'NoSuchKey' || err.$metadata?.httpStatusCode === 404) return [];
+    const status = err.$metadata?.httpStatusCode;
+    if (
+      err.name === 'NoSuchKey' ||
+      err.name === 'NotFound' ||
+      err.Code === 'NoSuchKey' ||
+      status === 404
+    ) return [];
+    console.error('bucket-store readStore error:', err.name, err.message);
     throw err;
   }
 }

--- a/api/buckets.js
+++ b/api/buckets.js
@@ -82,12 +82,18 @@ module.exports = async function handler(req, res) {
       const registeredNames = new Set(registered.map(b => b.name));
       // Flag whether shared credentials are configured
       const hasSharedCreds = !!(process.env.R2_SHARED_ACCESS_KEY_ID && process.env.R2_SHARED_SECRET_ACCESS_KEY);
-      const buckets = (data.result?.buckets || []).map(b => ({
-        name: b.name,
-        creationDate: b.creation_date,
-        endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-        alreadyAdded: registeredNames.has(b.name),
-      }));
+      const buckets = (data.result?.buckets || []).map(b => {
+        // Auto-detect public URL from CF domains if bucket has public access enabled
+        const publicDomain = b.domains?.find(d => d.enabled)?.domain || b.public_domain || null;
+        const publicUrl = publicDomain ? `https://${publicDomain}` : null;
+        return {
+          name: b.name,
+          creationDate: b.creation_date,
+          endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+          publicUrl,
+          alreadyAdded: registeredNames.has(b.name),
+        };
+      });
 
       return successResponse(res, { buckets, hasSharedCreds }, 'Cloudflare buckets retrieved');
     } catch (err) {
@@ -99,10 +105,11 @@ module.exports = async function handler(req, res) {
   // POST /api/buckets/cf-import — 1-click import using shared credentials from env
   if (method === 'POST' && path === '/buckets/cf-import') {
     try {
-      const { name, publicUrl } = req.body;
+      const { name, publicUrl: manualPublicUrl } = req.body;
       if (!name) return errorResponse(res, 400, 'name is required');
 
       const accountId = process.env.CF_ACCOUNT_ID;
+      const apiToken = process.env.CF_API_TOKEN;
       const accessKeyId = process.env.R2_SHARED_ACCESS_KEY_ID;
       const secretAccessKey = process.env.R2_SHARED_SECRET_ACCESS_KEY;
 
@@ -112,10 +119,27 @@ module.exports = async function handler(req, res) {
 
       const endpoint = `https://${accountId}.r2.cloudflarestorage.com`;
 
+      // Auto-detect public URL from CF API if token available
+      let autoPublicUrl = manualPublicUrl || '';
+      if (apiToken && !autoPublicUrl) {
+        try {
+          const cfRes = await fetch(
+            `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${encodeURIComponent(name)}`,
+            { headers: { 'Authorization': `Bearer ${apiToken}` } }
+          );
+          const cfData = await cfRes.json();
+          if (cfData.success && cfData.result) {
+            const b = cfData.result;
+            const publicDomain = b.domains?.find(d => d.enabled)?.domain || b.public_domain || null;
+            if (publicDomain) autoPublicUrl = `https://${publicDomain}`;
+          }
+        } catch (e) { /* non-fatal */ }
+      }
+
       // Validate shared credentials can access this bucket
       await validateCredentials({ name, endpoint, accessKeyId, secretAccessKey });
 
-      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl: publicUrl || '' });
+      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl: autoPublicUrl });
       return successResponse(res, toPublic(bucket), 'Bucket imported successfully');
     } catch (err) {
       console.error('CF import error:', err);
@@ -169,7 +193,25 @@ module.exports = async function handler(req, res) {
       // Validate credentials can actually access the bucket
       await validateCredentials({ name, endpoint, accessKeyId, secretAccessKey });
 
-      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl: publicUrl || '' });
+      // Auto-detect public URL from CF API if not manually provided
+      let resolvedPublicUrl = publicUrl || '';
+      const apiToken = process.env.CF_API_TOKEN;
+      if (apiToken && accountId && !resolvedPublicUrl) {
+        try {
+          const cfRes = await fetch(
+            `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${encodeURIComponent(name)}`,
+            { headers: { 'Authorization': `Bearer ${apiToken}` } }
+          );
+          const cfData = await cfRes.json();
+          if (cfData.success && cfData.result) {
+            const b = cfData.result;
+            const publicDomain = b.domains?.find(d => d.enabled)?.domain || b.public_domain || null;
+            if (publicDomain) resolvedPublicUrl = `https://${publicDomain}`;
+          }
+        } catch (e) { /* non-fatal */ }
+      }
+
+      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl: resolvedPublicUrl });
       return successResponse(res, toPublic(bucket), 'Bucket created successfully');
     } catch (err) {
       console.error('Create bucket error:', err);

--- a/api/buckets.js
+++ b/api/buckets.js
@@ -122,7 +122,11 @@ module.exports = async function handler(req, res) {
       return successResponse(res, buckets.map(toPublic), 'Buckets retrieved');
     } catch (err) {
       console.error('List buckets error:', err);
-      return errorResponse(res, 500, 'Failed to list buckets');
+      // Surface the real error in non-production for easier debugging
+      const msg = process.env.NODE_ENV === 'production'
+        ? 'Failed to list buckets'
+        : `Failed to list buckets: ${err.message}`;
+      return errorResponse(res, 500, msg);
     }
   }
 

--- a/api/buckets.js
+++ b/api/buckets.js
@@ -61,6 +61,24 @@ module.exports = async function handler(req, res) {
     }, 'Config retrieved');
   }
 
+  // GET /api/buckets/debug-cf/:name — raw CF API response for debugging domain detection
+  if (method === 'GET' && path.startsWith('/buckets/debug-cf/')) {
+    try {
+      const bucketName = decodeURIComponent(path.replace('/buckets/debug-cf/', ''));
+      const accountId = process.env.CF_ACCOUNT_ID;
+      const apiToken = process.env.CF_API_TOKEN;
+      if (!accountId || !apiToken) return errorResponse(res, 400, 'CF_ACCOUNT_ID and CF_API_TOKEN required');
+      const cfRes = await fetch(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${encodeURIComponent(bucketName)}`,
+        { headers: { 'Authorization': `Bearer ${apiToken}` } }
+      );
+      const cfData = await cfRes.json();
+      return successResponse(res, cfData, 'Raw CF response');
+    } catch (err) {
+      return errorResponse(res, 500, err.message);
+    }
+  }
+
   // GET /api/buckets/cf-list — list bucket names from Cloudflare API
   if (method === 'GET' && path === '/buckets/cf-list') {
     try {

--- a/api/buckets.js
+++ b/api/buckets.js
@@ -70,9 +70,10 @@ module.exports = async function handler(req, res) {
         return errorResponse(res, 400, msg);
       }
 
-      // Return only name + creation date — no credentials
       const registered = await listBuckets();
       const registeredNames = new Set(registered.map(b => b.name));
+      // Flag whether shared credentials are configured
+      const hasSharedCreds = !!(process.env.R2_SHARED_ACCESS_KEY_ID && process.env.R2_SHARED_SECRET_ACCESS_KEY);
       const buckets = (data.result?.buckets || []).map(b => ({
         name: b.name,
         creationDate: b.creation_date,
@@ -80,10 +81,37 @@ module.exports = async function handler(req, res) {
         alreadyAdded: registeredNames.has(b.name),
       }));
 
-      return successResponse(res, buckets, 'Cloudflare buckets retrieved');
+      return successResponse(res, { buckets, hasSharedCreds }, 'Cloudflare buckets retrieved');
     } catch (err) {
       console.error('CF list buckets error:', err);
       return errorResponse(res, 500, 'Failed to fetch from Cloudflare');
+    }
+  }
+
+  // POST /api/buckets/cf-import — 1-click import using shared credentials from env
+  if (method === 'POST' && path === '/buckets/cf-import') {
+    try {
+      const { name, publicUrl } = req.body;
+      if (!name) return errorResponse(res, 400, 'name is required');
+
+      const accountId = process.env.CF_ACCOUNT_ID;
+      const accessKeyId = process.env.R2_SHARED_ACCESS_KEY_ID;
+      const secretAccessKey = process.env.R2_SHARED_SECRET_ACCESS_KEY;
+
+      if (!accountId || !accessKeyId || !secretAccessKey) {
+        return errorResponse(res, 400, 'CF_ACCOUNT_ID, R2_SHARED_ACCESS_KEY_ID, and R2_SHARED_SECRET_ACCESS_KEY must be set in env');
+      }
+
+      const endpoint = `https://${accountId}.r2.cloudflarestorage.com`;
+
+      // Validate shared credentials can access this bucket
+      await validateCredentials({ name, endpoint, accessKeyId, secretAccessKey });
+
+      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl: publicUrl || '' });
+      return successResponse(res, toPublic(bucket), 'Bucket imported successfully');
+    } catch (err) {
+      console.error('CF import error:', err);
+      return errorResponse(res, 400, err.message);
     }
   }
 

--- a/api/buckets.js
+++ b/api/buckets.js
@@ -53,6 +53,40 @@ module.exports = async function handler(req, res) {
     return errorResponse(res, 401, 'Authentication required');
   }
 
+  // GET /api/buckets/cf-list — list bucket names from Cloudflare API
+  if (method === 'GET' && path === '/buckets/cf-list') {
+    try {
+      const accountId = process.env.CF_ACCOUNT_ID;
+      const apiToken = process.env.CF_API_TOKEN;
+      if (!accountId || !apiToken) return errorResponse(res, 400, 'CF_ACCOUNT_ID and CF_API_TOKEN not configured in env');
+
+      const cfRes = await fetch(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets`,
+        { headers: { 'Authorization': `Bearer ${apiToken}` } }
+      );
+      const data = await cfRes.json();
+      if (!data.success) {
+        const msg = data.errors?.[0]?.message || 'Failed to fetch buckets from Cloudflare';
+        return errorResponse(res, 400, msg);
+      }
+
+      // Return only name + creation date — no credentials
+      const registered = await listBuckets();
+      const registeredNames = new Set(registered.map(b => b.name));
+      const buckets = (data.result?.buckets || []).map(b => ({
+        name: b.name,
+        creationDate: b.creation_date,
+        endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+        alreadyAdded: registeredNames.has(b.name),
+      }));
+
+      return successResponse(res, buckets, 'Cloudflare buckets retrieved');
+    } catch (err) {
+      console.error('CF list buckets error:', err);
+      return errorResponse(res, 500, 'Failed to fetch from Cloudflare');
+    }
+  }
+
   // GET /api/buckets — list all buckets (public view, no credentials)
   if (method === 'GET' && (path === '/buckets' || path === '/buckets/')) {
     try {

--- a/api/buckets.js
+++ b/api/buckets.js
@@ -61,24 +61,6 @@ module.exports = async function handler(req, res) {
     }, 'Config retrieved');
   }
 
-  // GET /api/buckets/debug-cf/:name — raw CF API response for debugging domain detection
-  if (method === 'GET' && path.startsWith('/buckets/debug-cf/')) {
-    try {
-      const bucketName = decodeURIComponent(path.replace('/buckets/debug-cf/', ''));
-      const accountId = process.env.CF_ACCOUNT_ID;
-      const apiToken = process.env.CF_API_TOKEN;
-      if (!accountId || !apiToken) return errorResponse(res, 400, 'CF_ACCOUNT_ID and CF_API_TOKEN required');
-      const cfRes = await fetch(
-        `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${encodeURIComponent(bucketName)}`,
-        { headers: { 'Authorization': `Bearer ${apiToken}` } }
-      );
-      const cfData = await cfRes.json();
-      return successResponse(res, cfData, 'Raw CF response');
-    } catch (err) {
-      return errorResponse(res, 500, err.message);
-    }
-  }
-
   // GET /api/buckets/cf-list — list bucket names from Cloudflare API
   if (method === 'GET' && path === '/buckets/cf-list') {
     try {
@@ -137,27 +119,10 @@ module.exports = async function handler(req, res) {
 
       const endpoint = `https://${accountId}.r2.cloudflarestorage.com`;
 
-      // Auto-detect public URL from CF API if token available
-      let autoPublicUrl = manualPublicUrl || '';
-      if (apiToken && !autoPublicUrl) {
-        try {
-          const cfRes = await fetch(
-            `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${encodeURIComponent(name)}`,
-            { headers: { 'Authorization': `Bearer ${apiToken}` } }
-          );
-          const cfData = await cfRes.json();
-          if (cfData.success && cfData.result) {
-            const b = cfData.result;
-            const publicDomain = (b.domains || b.custom_domains || []).find(d => d.enabled || d.status === 'active' || d.status === 'Active')?.domain || b.public_domain || null;
-            if (publicDomain) autoPublicUrl = `https://${publicDomain}`;
-          }
-        } catch (e) { /* non-fatal */ }
-      }
-
       // Validate shared credentials can access this bucket
       await validateCredentials({ name, endpoint, accessKeyId, secretAccessKey });
 
-      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl: autoPublicUrl });
+      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl: manualPublicUrl || '' });
       return successResponse(res, toPublic(bucket), 'Bucket imported successfully');
     } catch (err) {
       console.error('CF import error:', err);
@@ -211,25 +176,7 @@ module.exports = async function handler(req, res) {
       // Validate credentials can actually access the bucket
       await validateCredentials({ name, endpoint, accessKeyId, secretAccessKey });
 
-      // Auto-detect public URL from CF API if not manually provided
-      let resolvedPublicUrl = publicUrl || '';
-      const apiToken = process.env.CF_API_TOKEN;
-      if (apiToken && accountId && !resolvedPublicUrl) {
-        try {
-          const cfRes = await fetch(
-            `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${encodeURIComponent(name)}`,
-            { headers: { 'Authorization': `Bearer ${apiToken}` } }
-          );
-          const cfData = await cfRes.json();
-          if (cfData.success && cfData.result) {
-            const b = cfData.result;
-            const publicDomain = (b.domains || b.custom_domains || []).find(d => d.enabled || d.status === 'active' || d.status === 'Active')?.domain || b.public_domain || null;
-            if (publicDomain) resolvedPublicUrl = `https://${publicDomain}`;
-          }
-        } catch (e) { /* non-fatal */ }
-      }
-
-      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl: resolvedPublicUrl });
+      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl: publicUrl || '' });
       return successResponse(res, toPublic(bucket), 'Bucket created successfully');
     } catch (err) {
       console.error('Create bucket error:', err);
@@ -237,34 +184,18 @@ module.exports = async function handler(req, res) {
     }
   }
 
-  // POST /api/buckets/:id/sync — refresh public URL from Cloudflare API
+  // POST /api/buckets/:id/sync — update publicUrl manually
   const syncMatch = path.match(/^\/buckets\/([^/]+)\/sync$/);
   if (method === 'POST' && syncMatch) {
     try {
       const id = syncMatch[1];
-      const bucket = await getBucketById(id);
-      if (!bucket) return errorResponse(res, 404, 'Bucket not found');
-
-      const accountId = process.env.CF_ACCOUNT_ID;
-      const apiToken = process.env.CF_API_TOKEN;
-      if (!accountId || !apiToken) return errorResponse(res, 400, 'CF_ACCOUNT_ID and CF_API_TOKEN required for sync');
-
-      const cfRes = await fetch(
-        `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${encodeURIComponent(bucket.name)}`,
-        { headers: { 'Authorization': `Bearer ${apiToken}` } }
-      );
-      const cfData = await cfRes.json();
-      if (!cfData.success) return errorResponse(res, 400, cfData.errors?.[0]?.message || 'CF API error');
-
-      const b = cfData.result;
-      const publicDomain = (b.domains || b.custom_domains || []).find(d => d.enabled || d.status === 'active' || d.status === 'Active')?.domain || b.public_domain || null;
-      const publicUrl = publicDomain ? `https://${publicDomain}` : '';
-
-      const updated = await updateBucket(id, { publicUrl });
-      return successResponse(res, toPublic(updated), publicUrl ? `Public URL synced: ${publicUrl}` : 'No public domain found on this bucket');
+      const { publicUrl } = req.body;
+      if (publicUrl === undefined) return errorResponse(res, 400, 'publicUrl is required');
+      const updated = await updateBucket(id, { publicUrl: publicUrl || '' });
+      if (!updated) return errorResponse(res, 404, 'Bucket not found');
+      return successResponse(res, toPublic(updated), 'Public URL updated');
     } catch (err) {
-      console.error('Sync bucket error:', err);
-      return errorResponse(res, 500, 'Failed to sync bucket');
+      return errorResponse(res, 500, 'Failed to update bucket');
     }
   }
 

--- a/api/buckets.js
+++ b/api/buckets.js
@@ -1,5 +1,5 @@
 const { authenticateToken, handleCors, errorResponse, successResponse } = require('./utils');
-const { listBuckets, getBucketById, addBucket, deleteBucket, toPublic } = require('./bucket-store');
+const { listBuckets, getBucketById, addBucket, updateBucket, deleteBucket, toPublic } = require('./bucket-store');
 const { createR2Client } = require('./r2-client');
 const { ListObjectsV2Command } = require('@aws-sdk/client-s3');
 
@@ -84,7 +84,7 @@ module.exports = async function handler(req, res) {
       const hasSharedCreds = !!(process.env.R2_SHARED_ACCESS_KEY_ID && process.env.R2_SHARED_SECRET_ACCESS_KEY);
       const buckets = (data.result?.buckets || []).map(b => {
         // Auto-detect public URL from CF domains if bucket has public access enabled
-        const publicDomain = b.domains?.find(d => d.enabled)?.domain || b.public_domain || null;
+        const publicDomain = b.domains?.find(d => d.enabled || d.status === 'active')?.domain || b.public_domain || null;
         const publicUrl = publicDomain ? `https://${publicDomain}` : null;
         return {
           name: b.name,
@@ -130,7 +130,7 @@ module.exports = async function handler(req, res) {
           const cfData = await cfRes.json();
           if (cfData.success && cfData.result) {
             const b = cfData.result;
-            const publicDomain = b.domains?.find(d => d.enabled)?.domain || b.public_domain || null;
+            const publicDomain = b.domains?.find(d => d.enabled || d.status === 'active')?.domain || b.public_domain || null;
             if (publicDomain) autoPublicUrl = `https://${publicDomain}`;
           }
         } catch (e) { /* non-fatal */ }
@@ -205,7 +205,7 @@ module.exports = async function handler(req, res) {
           const cfData = await cfRes.json();
           if (cfData.success && cfData.result) {
             const b = cfData.result;
-            const publicDomain = b.domains?.find(d => d.enabled)?.domain || b.public_domain || null;
+            const publicDomain = b.domains?.find(d => d.enabled || d.status === 'active')?.domain || b.public_domain || null;
             if (publicDomain) resolvedPublicUrl = `https://${publicDomain}`;
           }
         } catch (e) { /* non-fatal */ }
@@ -216,6 +216,37 @@ module.exports = async function handler(req, res) {
     } catch (err) {
       console.error('Create bucket error:', err);
       return errorResponse(res, 400, err.message);
+    }
+  }
+
+  // POST /api/buckets/:id/sync — refresh public URL from Cloudflare API
+  const syncMatch = path.match(/^\/buckets\/([^/]+)\/sync$/);
+  if (method === 'POST' && syncMatch) {
+    try {
+      const id = syncMatch[1];
+      const bucket = await getBucketById(id);
+      if (!bucket) return errorResponse(res, 404, 'Bucket not found');
+
+      const accountId = process.env.CF_ACCOUNT_ID;
+      const apiToken = process.env.CF_API_TOKEN;
+      if (!accountId || !apiToken) return errorResponse(res, 400, 'CF_ACCOUNT_ID and CF_API_TOKEN required for sync');
+
+      const cfRes = await fetch(
+        `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets/${encodeURIComponent(bucket.name)}`,
+        { headers: { 'Authorization': `Bearer ${apiToken}` } }
+      );
+      const cfData = await cfRes.json();
+      if (!cfData.success) return errorResponse(res, 400, cfData.errors?.[0]?.message || 'CF API error');
+
+      const b = cfData.result;
+      const publicDomain = b.domains?.find(d => d.enabled || d.status === 'active')?.domain || b.public_domain || null;
+      const publicUrl = publicDomain ? `https://${publicDomain}` : '';
+
+      const updated = await updateBucket(id, { publicUrl });
+      return successResponse(res, toPublic(updated), publicUrl ? `Public URL synced: ${publicUrl}` : 'No public domain found on this bucket');
+    } catch (err) {
+      console.error('Sync bucket error:', err);
+      return errorResponse(res, 500, 'Failed to sync bucket');
     }
   }
 

--- a/api/buckets.js
+++ b/api/buckets.js
@@ -53,6 +53,14 @@ module.exports = async function handler(req, res) {
     return errorResponse(res, 401, 'Authentication required');
   }
 
+  // GET /api/buckets/config — expose panel config flags to frontend
+  if (method === 'GET' && path === '/buckets/config') {
+    return successResponse(res, {
+      hasSharedCreds: !!(process.env.R2_SHARED_ACCESS_KEY_ID && process.env.R2_SHARED_SECRET_ACCESS_KEY),
+      hasCfConfig: !!(process.env.CF_ACCOUNT_ID && process.env.CF_API_TOKEN),
+    }, 'Config retrieved');
+  }
+
   // GET /api/buckets/cf-list — list bucket names from Cloudflare API
   if (method === 'GET' && path === '/buckets/cf-list') {
     try {
@@ -130,13 +138,22 @@ module.exports = async function handler(req, res) {
     }
   }
 
-  // POST /api/buckets — create new bucket
+  // POST /api/buckets — create/register new bucket
   if (method === 'POST' && (path === '/buckets' || path === '/buckets/')) {
     try {
-      const { name, endpoint, accessKeyId, secretAccessKey, publicUrl, createOnCloudflare } = req.body;
+      const { name, publicUrl, createOnCloudflare } = req.body;
+      let { endpoint, accessKeyId, secretAccessKey } = req.body;
 
-      if (!name || !endpoint || !accessKeyId || !secretAccessKey) {
-        return errorResponse(res, 400, 'name, endpoint, accessKeyId, secretAccessKey are required');
+      if (!name) return errorResponse(res, 400, 'name is required');
+
+      // Fall back to shared credentials from env if not provided
+      const accountId = process.env.CF_ACCOUNT_ID;
+      if (!accessKeyId) accessKeyId = process.env.R2_SHARED_ACCESS_KEY_ID;
+      if (!secretAccessKey) secretAccessKey = process.env.R2_SHARED_SECRET_ACCESS_KEY;
+      if (!endpoint && accountId) endpoint = `https://${accountId}.r2.cloudflarestorage.com`;
+
+      if (!endpoint || !accessKeyId || !secretAccessKey) {
+        return errorResponse(res, 400, 'endpoint, accessKeyId, secretAccessKey are required (or set R2_SHARED_* in env)');
       }
 
       // Validate bucket name (R2 rules: lowercase, alphanumeric, hyphens)
@@ -152,7 +169,7 @@ module.exports = async function handler(req, res) {
       // Validate credentials can actually access the bucket
       await validateCredentials({ name, endpoint, accessKeyId, secretAccessKey });
 
-      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl });
+      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl: publicUrl || '' });
       return successResponse(res, toPublic(bucket), 'Bucket created successfully');
     } catch (err) {
       console.error('Create bucket error:', err);

--- a/api/buckets.js
+++ b/api/buckets.js
@@ -1,0 +1,112 @@
+const { authenticateToken, handleCors, errorResponse, successResponse } = require('./utils');
+const { listBuckets, getBucketById, addBucket, deleteBucket, toPublic } = require('./bucket-store');
+const { createR2Client } = require('./r2-client');
+const { ListObjectsV2Command } = require('@aws-sdk/client-s3');
+
+// Create bucket in Cloudflare R2 via CF API
+async function createCloudflareBucket(name) {
+  const accountId = process.env.CF_ACCOUNT_ID;
+  const apiToken = process.env.CF_API_TOKEN;
+  if (!accountId || !apiToken) throw new Error('CF_ACCOUNT_ID and CF_API_TOKEN are required');
+
+  const res = await fetch(
+    `https://api.cloudflare.com/client/v4/accounts/${accountId}/r2/buckets`,
+    {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name }),
+    }
+  );
+
+  const data = await res.json();
+  if (!data.success) {
+    const msg = data.errors?.[0]?.message || 'Failed to create bucket on Cloudflare';
+    throw new Error(msg);
+  }
+  return data.result;
+}
+
+// Validate R2 credentials by attempting a list operation
+async function validateCredentials(config) {
+  try {
+    const client = createR2Client(config);
+    await client.send(new ListObjectsV2Command({ Bucket: config.name, MaxKeys: 1 }));
+    return true;
+  } catch (err) {
+    throw new Error(`Invalid credentials or bucket not accessible: ${err.message}`);
+  }
+}
+
+module.exports = async function handler(req, res) {
+  if (handleCors(req, res)) return;
+
+  const path = req.path || req.url || '';
+  const method = req.method;
+
+  // All bucket management requires JWT auth
+  try {
+    authenticateToken(req);
+  } catch (err) {
+    return errorResponse(res, 401, 'Authentication required');
+  }
+
+  // GET /api/buckets — list all buckets (public view, no credentials)
+  if (method === 'GET' && (path === '/buckets' || path === '/buckets/')) {
+    try {
+      const buckets = await listBuckets();
+      return successResponse(res, buckets.map(toPublic), 'Buckets retrieved');
+    } catch (err) {
+      console.error('List buckets error:', err);
+      return errorResponse(res, 500, 'Failed to list buckets');
+    }
+  }
+
+  // POST /api/buckets — create new bucket
+  if (method === 'POST' && (path === '/buckets' || path === '/buckets/')) {
+    try {
+      const { name, endpoint, accessKeyId, secretAccessKey, publicUrl, createOnCloudflare } = req.body;
+
+      if (!name || !endpoint || !accessKeyId || !secretAccessKey) {
+        return errorResponse(res, 400, 'name, endpoint, accessKeyId, secretAccessKey are required');
+      }
+
+      // Validate bucket name (R2 rules: lowercase, alphanumeric, hyphens)
+      if (!/^[a-z0-9][a-z0-9-]{1,61}[a-z0-9]$/.test(name)) {
+        return errorResponse(res, 400, 'Invalid bucket name. Use lowercase letters, numbers, and hyphens (3-63 chars)');
+      }
+
+      // Optionally create bucket on Cloudflare first
+      if (createOnCloudflare) {
+        await createCloudflareBucket(name);
+      }
+
+      // Validate credentials can actually access the bucket
+      await validateCredentials({ name, endpoint, accessKeyId, secretAccessKey });
+
+      const bucket = await addBucket({ name, endpoint, accessKeyId, secretAccessKey, publicUrl });
+      return successResponse(res, toPublic(bucket), 'Bucket created successfully');
+    } catch (err) {
+      console.error('Create bucket error:', err);
+      return errorResponse(res, 400, err.message);
+    }
+  }
+
+  // DELETE /api/buckets/:id — remove bucket from panel (does NOT delete from Cloudflare)
+  const deleteMatch = path.match(/^\/buckets\/([^/]+)$/);
+  if (method === 'DELETE' && deleteMatch) {
+    try {
+      const id = deleteMatch[1];
+      const deleted = await deleteBucket(id);
+      if (!deleted) return errorResponse(res, 404, 'Bucket not found');
+      return successResponse(res, null, 'Bucket removed from panel');
+    } catch (err) {
+      console.error('Delete bucket error:', err);
+      return errorResponse(res, 500, 'Failed to remove bucket');
+    }
+  }
+
+  return errorResponse(res, 404, 'Not found');
+};

--- a/api/buckets.js
+++ b/api/buckets.js
@@ -102,7 +102,7 @@ module.exports = async function handler(req, res) {
       const hasSharedCreds = !!(process.env.R2_SHARED_ACCESS_KEY_ID && process.env.R2_SHARED_SECRET_ACCESS_KEY);
       const buckets = (data.result?.buckets || []).map(b => {
         // Auto-detect public URL from CF domains if bucket has public access enabled
-        const publicDomain = b.domains?.find(d => d.enabled || d.status === 'active')?.domain || b.public_domain || null;
+        const publicDomain = (b.domains || b.custom_domains || []).find(d => d.enabled || d.status === 'active' || d.status === 'Active')?.domain || b.public_domain || null;
         const publicUrl = publicDomain ? `https://${publicDomain}` : null;
         return {
           name: b.name,
@@ -148,7 +148,7 @@ module.exports = async function handler(req, res) {
           const cfData = await cfRes.json();
           if (cfData.success && cfData.result) {
             const b = cfData.result;
-            const publicDomain = b.domains?.find(d => d.enabled || d.status === 'active')?.domain || b.public_domain || null;
+            const publicDomain = (b.domains || b.custom_domains || []).find(d => d.enabled || d.status === 'active' || d.status === 'Active')?.domain || b.public_domain || null;
             if (publicDomain) autoPublicUrl = `https://${publicDomain}`;
           }
         } catch (e) { /* non-fatal */ }
@@ -223,7 +223,7 @@ module.exports = async function handler(req, res) {
           const cfData = await cfRes.json();
           if (cfData.success && cfData.result) {
             const b = cfData.result;
-            const publicDomain = b.domains?.find(d => d.enabled || d.status === 'active')?.domain || b.public_domain || null;
+            const publicDomain = (b.domains || b.custom_domains || []).find(d => d.enabled || d.status === 'active' || d.status === 'Active')?.domain || b.public_domain || null;
             if (publicDomain) resolvedPublicUrl = `https://${publicDomain}`;
           }
         } catch (e) { /* non-fatal */ }
@@ -257,7 +257,7 @@ module.exports = async function handler(req, res) {
       if (!cfData.success) return errorResponse(res, 400, cfData.errors?.[0]?.message || 'CF API error');
 
       const b = cfData.result;
-      const publicDomain = b.domains?.find(d => d.enabled || d.status === 'active')?.domain || b.public_domain || null;
+      const publicDomain = (b.domains || b.custom_domains || []).find(d => d.enabled || d.status === 'active' || d.status === 'Active')?.domain || b.public_domain || null;
       const publicUrl = publicDomain ? `https://${publicDomain}` : '';
 
       const updated = await updateBucket(id, { publicUrl });

--- a/api/files.js
+++ b/api/files.js
@@ -46,7 +46,7 @@ module.exports = async function handler(req, res) {
       let files = await Promise.all((result.Contents || []).map(async obj => {
         const publicUrl = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${obj.Key}` : null;
         let presignedUrl = null;
-        try { presignedUrl = await getPresignedUrl(client, { Bucket: bucketName, Key: obj.Key, expiresIn: 3600 }); } catch (e) {}
+        try { presignedUrl = await getPresignedUrl(client, { Bucket: bucketName, Key: obj.Key, expiresIn: 604800 }); } catch (e) {}
         return { key: obj.Key, filename: obj.Key, size: obj.Size, lastModified: obj.LastModified, contentType: getContentTypeFromKey(obj.Key), publicUrl, presignedUrl, downloadUrl: `/r2/download/${encodeURIComponent(obj.Key)}` };
       }));
 

--- a/api/files.js
+++ b/api/files.js
@@ -1,154 +1,57 @@
-const { authenticateApiKey, authenticateHybrid, handleCors, errorResponse, successResponse } = require('./utils');
-const { listObjects, putObject, headObject, deleteObject, getObject, getPresignedUrl } = require('./r2-client');
+const { authenticateHybrid, handleCors, errorResponse, successResponse, setCookie } = require('./utils');
+const { resolveClientAndBucket, listObjects, putObject, headObject, deleteObject, getPresignedUrl } = require('./r2-client');
 const formidable = require('formidable');
 
-// Helper: get key from req
 function getKey(req) {
-  if (req.query && req.query.key) return req.query.key;
-  if (req.query && req.query["[key]"]) return req.query["[key]"];
-  if (req.url && req.url.match(/\/([^\/]+)$/)) return decodeURIComponent(req.url.match(/\/([^\/]+)$/)[1]);
+  if (req.query?.key) return req.query.key;
+  if (req.url?.match(/\/([^/]+)$/)) return decodeURIComponent(req.url.match(/\/([^/]+)$/)[1]);
   return null;
 }
 
-// Helper: get content type from file extension
 function getContentTypeFromKey(key) {
   const ext = key.toLowerCase().split('.').pop();
-  const mimeTypes = {
-    // Images
-    'jpg': 'image/jpeg',
-    'jpeg': 'image/jpeg',
-    'png': 'image/png',
-    'gif': 'image/gif',
-    'webp': 'image/webp',
-    'svg': 'image/svg+xml',
-    'bmp': 'image/bmp',
-    'ico': 'image/x-icon',
-    
-    // Videos
-    'mp4': 'video/mp4',
-    'avi': 'video/x-msvideo',
-    'mov': 'video/quicktime',
-    'wmv': 'video/x-ms-wmv',
-    'flv': 'video/x-flv',
-    'webm': 'video/webm',
-    'mkv': 'video/x-matroska',
-    
-    // Audio
-    'mp3': 'audio/mpeg',
-    'wav': 'audio/wav',
-    'ogg': 'audio/ogg',
-    'aac': 'audio/aac',
-    'flac': 'audio/flac',
-    'm4a': 'audio/mp4',
-    
-    // Documents
-    'pdf': 'application/pdf',
-    'doc': 'application/msword',
-    'docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-    'xls': 'application/vnd.ms-excel',
-    'xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-    'ppt': 'application/vnd.ms-powerpoint',
-    'pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
-    
-    // Text
-    'txt': 'text/plain',
-    'html': 'text/html',
-    'css': 'text/css',
-    'js': 'application/javascript',
-    'json': 'application/json',
-    'xml': 'application/xml',
-    'csv': 'text/csv',
-    
-    // Archives
-    'zip': 'application/zip',
-    'rar': 'application/vnd.rar',
-    '7z': 'application/x-7z-compressed',
-    'tar': 'application/x-tar',
-    'gz': 'application/gzip'
-  };
-  
-  return mimeTypes[ext] || 'application/octet-stream';
+  const m = { jpg:'image/jpeg',jpeg:'image/jpeg',png:'image/png',gif:'image/gif',webp:'image/webp',svg:'image/svg+xml',mp4:'video/mp4',webm:'video/webm',mp3:'audio/mpeg',wav:'audio/wav',pdf:'application/pdf',txt:'text/plain',json:'application/json',zip:'application/zip' };
+  return m[ext] || 'application/octet-stream';
+}
+
+function getFileType(contentType) {
+  if (!contentType) return 'doc';
+  if (contentType.startsWith('image/')) return 'image';
+  if (contentType.startsWith('video/')) return 'video';
+  if (contentType.startsWith('audio/')) return 'audio';
+  if (['application/zip','application/vnd.rar','application/x-7z-compressed','application/x-tar','application/gzip'].includes(contentType)) return 'archive';
+  return 'doc';
 }
 
 module.exports = async function handler(req, res) {
   if (handleCors(req, res)) return;
 
-  // --- List files (GET /api/files) ---
+  let ctx;
+  try {
+    ctx = await resolveClientAndBucket(req);
+  } catch (err) {
+    return errorResponse(res, 400, err.message);
+  }
+  const { client, bucketName, publicUrl: baseUrl } = ctx;
+
+  // GET /api/files
   if (req.method === 'GET' && req.url.startsWith('/files')) {
     try {
-      const { user, newAccessToken } = authenticateHybrid(req);
-      // Set new access token if JWT was refreshed
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
+      const { newAccessToken } = authenticateHybrid(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
       const { token, prefix, limit, search, type } = req.query;
-      const Bucket = process.env.R2_BUCKET_NAME;
-      if (!Bucket) return errorResponse(res, 500, 'Server configuration error: Bucket name is missing.');
-      const result = await listObjects({
-        Bucket,
-        ContinuationToken: token || undefined,
-        Prefix: typeof prefix === 'string' ? prefix : undefined,
-        MaxKeys: parseInt(limit, 10) || 100
-      });
-      const baseUrl = process.env.R2_PUBLIC_URL || '';
+      const result = await listObjects(client, { Bucket: bucketName, ContinuationToken: token || undefined, Prefix: typeof prefix === 'string' ? prefix : undefined, MaxKeys: parseInt(limit, 10) || 100 });
+
       let files = await Promise.all((result.Contents || []).map(async obj => {
         const publicUrl = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${obj.Key}` : null;
         let presignedUrl = null;
-        try {
-          presignedUrl = await getPresignedUrl ? await getPresignedUrl({
-            Bucket,
-            Key: obj.Key,
-            expiresIn: 3600
-          }) : null;
-        } catch (e) {
-          presignedUrl = null;
-        }
-        return {
-          key: obj.Key,
-          filename: obj.Key,
-          size: obj.Size,
-          lastModified: obj.LastModified,
-          contentType: getContentTypeFromKey(obj.Key),
-          publicUrl,
-          presignedUrl,
-          downloadUrl: `/r2/download/${encodeURIComponent(obj.Key)}`
-        };
+        try { presignedUrl = await getPresignedUrl(client, { Bucket: bucketName, Key: obj.Key, expiresIn: 3600 }); } catch (e) {}
+        return { key: obj.Key, filename: obj.Key, size: obj.Size, lastModified: obj.LastModified, contentType: getContentTypeFromKey(obj.Key), publicUrl, presignedUrl, downloadUrl: `/r2/download/${encodeURIComponent(obj.Key)}` };
       }));
 
-      // --- Backend Filtering ---
-      if (search && typeof search === 'string') {
-        const searchLower = search.toLowerCase();
-        files = files.filter(f => f.key.toLowerCase().includes(searchLower));
-      }
-      if (type && type !== 'all') {
-        // getFileType logic: match frontend
-        const getFileType = (contentType) => {
-          if (!contentType) return 'doc';
-          if (contentType.startsWith('image/')) return 'image';
-          if (contentType.startsWith('video/')) return 'video';
-          if (contentType.startsWith('audio/')) return 'audio';
-          if ([
-            'application/pdf',
-            'application/msword',
-            'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-            'application/vnd.ms-excel',
-            'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-            'text/plain',
-            'text/csv'
-          ].includes(contentType)) return 'doc';
-          if ([
-            'application/zip',
-            'application/vnd.rar',
-            'application/x-7z-compressed',
-            'application/x-tar',
-            'application/gzip'
-          ].includes(contentType)) return 'archive';
-          return 'doc';
-        };
-        files = files.filter(f => getFileType(f.contentType) === type);
-      }
+      if (search) files = files.filter(f => f.key.toLowerCase().includes(search.toLowerCase()));
+      if (type && type !== 'all') files = files.filter(f => getFileType(f.contentType) === type);
 
       return successResponse(res, { files, pagination: { nextToken: result.NextContinuationToken || null, isTruncated: result.IsTruncated || false, count: files.length } });
     } catch (error) {
@@ -158,29 +61,25 @@ module.exports = async function handler(req, res) {
     }
   }
 
-  // --- Upload file (POST /api/files/upload) ---
+  // POST /api/files/upload
   if (req.method === 'POST' && req.url === '/files/upload') {
     try {
-      const { user, newAccessToken } = authenticateHybrid(req);
-      // Set new access token if JWT was refreshed
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
+      const { newAccessToken } = authenticateHybrid(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
       const form = new formidable.IncomingForm({ maxFileSize: 25 * 1024 * 1024, maxFiles: 1 });
-      const [fields, files] = await form.parse(req);
-      if (!files.file || files.file.length === 0) return errorResponse(res, 400, 'No file uploaded');
+      const [, files] = await form.parse(req);
+      if (!files.file?.length) return errorResponse(res, 400, 'No file uploaded');
       const file = Array.isArray(files.file) ? files.file[0] : files.file;
-      if (!file.size || file.size === 0) return errorResponse(res, 400, 'Empty file uploaded');
-      const originalName = file.originalFilename || file.name || 'unknown';
-      const filename = Date.now() + '-' + originalName;
+      if (!file.size) return errorResponse(res, 400, 'Empty file uploaded');
+
       const fs = require('fs');
+      const originalName = file.originalFilename || 'unknown';
+      const filename = `${Date.now()}-${originalName}`;
       const fileBuffer = fs.readFileSync(file.filepath);
-      await putObject({ Bucket: process.env.R2_BUCKET_NAME, Key: filename, Body: fileBuffer, ContentType: file.mimetype || 'application/octet-stream' });
-      const baseUrl = process.env.R2_PUBLIC_URL || '';
-      const publicUrl = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${filename}` : null;
-      return successResponse(res, { filename, key: filename, size: file.size, contentType: file.mimetype || 'application/octet-stream', url: publicUrl, downloadUrl: `/r2/download/${filename}` });
+      await putObject(client, { Bucket: bucketName, Key: filename, Body: fileBuffer, ContentType: file.mimetype || 'application/octet-stream' });
+      const url = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${filename}` : null;
+      return successResponse(res, { filename, key: filename, size: file.size, contentType: file.mimetype, url, downloadUrl: `/r2/download/${filename}` });
     } catch (error) {
       console.error('API Upload error:', error);
       if (error.message.includes('API key') || error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
@@ -188,89 +87,38 @@ module.exports = async function handler(req, res) {
     }
   }
 
-  // --- Upload & Convert to WebP (POST /api/files/upload-webp) ---
+  // POST /api/files/upload-webp
   if (req.method === 'POST' && req.url === '/files/upload-webp') {
     try {
-      const { user, newAccessToken } = authenticateHybrid(req);
-      // Set new access token if JWT was refreshed
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
-      
+      const { newAccessToken } = authenticateHybrid(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
       const form = new formidable.IncomingForm({ maxFileSize: 10 * 1024 * 1024, maxFiles: 1 });
       const [fields, files] = await form.parse(req);
-      
-      if (!files.image || files.image.length === 0) return errorResponse(res, 400, 'No image file uploaded');
+      if (!files.image?.length) return errorResponse(res, 400, 'No image uploaded');
       const file = Array.isArray(files.image) ? files.image[0] : files.image;
-      if (!file.size || file.size === 0) return errorResponse(res, 400, 'Empty file uploaded');
-      
-      // Check if file is an image
-      if (!file.mimetype || !file.mimetype.startsWith('image/')) {
-        return errorResponse(res, 400, 'Only image files are allowed');
-      }
-      
-      const sharp = require('sharp');
+      if (!file.size) return errorResponse(res, 400, 'Empty file uploaded');
+      if (!file.mimetype?.startsWith('image/')) return errorResponse(res, 400, 'Only image files allowed');
+
       const fs = require('fs');
-      const originalName = file.originalFilename || file.name || 'unknown';
+      const sharp = require('sharp');
+      const originalName = file.originalFilename || 'unknown';
       const quality = parseInt(fields.quality?.[0] || fields.quality || 80, 10);
-      
       let fileBuffer = fs.readFileSync(file.filepath);
       let fileName = originalName;
-      let contentType = 'image/webp';
       let wasConverted = false;
 
-      // Check if file is already WebP
       if (file.mimetype !== 'image/webp') {
-        console.log(`Converting ${fileName} to WebP format...`);
-        
-        // Convert to WebP
-        try {
-          fileBuffer = await sharp(fileBuffer).webp({ quality }).toBuffer();
-          wasConverted = true;
-          
-          // Update filename to have .webp extension
-          const nameWithoutExt = fileName.substring(0, fileName.lastIndexOf('.')) || fileName;
-          fileName = `${nameWithoutExt}.webp`;
-        } catch (convertError) {
-          console.error('WebP conversion error:', convertError);
-          return errorResponse(res, 500, 'Failed to convert image to WebP', convertError.message);
-        }
+        fileBuffer = await sharp(fileBuffer).webp({ quality }).toBuffer();
+        wasConverted = true;
+        const base = fileName.substring(0, fileName.lastIndexOf('.')) || fileName;
+        fileName = `${base}.webp`;
       }
 
-      // Generate unique filename with timestamp
-      const timestamp = Date.now();
-      const uniqueFileName = `webp/${timestamp}-${fileName}`;
-
-      // Upload to R2
-      await putObject({ 
-        Bucket: process.env.R2_BUCKET_NAME, 
-        Key: uniqueFileName, 
-        Body: fileBuffer, 
-        ContentType: contentType 
-      });
-      
-      const baseUrl = process.env.R2_PUBLIC_URL || '';
-      const publicUrl = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${uniqueFileName}` : null;
-      
-      return successResponse(
-        res,
-        {
-          filename: uniqueFileName,
-          key: uniqueFileName,
-          originalName: originalName,
-          convertedName: fileName,
-          size: fileBuffer.length,
-          contentType: contentType,
-          url: publicUrl,
-          downloadUrl: `/r2/download/${uniqueFileName}`,
-          wasConverted: wasConverted,
-          originalFormat: file.mimetype,
-          uploadedAt: new Date().toISOString()
-        },
-        'Image uploaded and converted successfully'
-      );
+      const uniqueKey = `webp/${Date.now()}-${fileName}`;
+      await putObject(client, { Bucket: bucketName, Key: uniqueKey, Body: fileBuffer, ContentType: 'image/webp' });
+      const url = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${uniqueKey}` : null;
+      return successResponse(res, { filename: uniqueKey, key: uniqueKey, originalName, convertedName: fileName, size: fileBuffer.length, contentType: 'image/webp', url, downloadUrl: `/r2/download/${uniqueKey}`, wasConverted, originalFormat: file.mimetype, uploadedAt: new Date().toISOString() }, 'Image uploaded and converted successfully');
     } catch (error) {
       console.error('API WebP Upload error:', error);
       if (error.message.includes('API key') || error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
@@ -278,26 +126,19 @@ module.exports = async function handler(req, res) {
     }
   }
 
-  // --- Delete file (DELETE /api/files/:key) ---
+  // DELETE /api/files/:key
   if (req.method === 'DELETE' && req.url.startsWith('/files/')) {
     try {
-      const { user, newAccessToken } = authenticateHybrid(req);
-      // Set new access token if JWT was refreshed
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
+      const { newAccessToken } = authenticateHybrid(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
       const key = getKey(req);
       if (!key) return errorResponse(res, 400, 'File key is required');
-      const Bucket = process.env.R2_BUCKET_NAME;
-      try {
-        await headObject({ Bucket, Key: key });
-      } catch (err) {
-        if (err.name === 'NotFound' || err.message.includes('not found')) return errorResponse(res, 404, 'File not found');
+      try { await headObject(client, { Bucket: bucketName, Key: key }); } catch (err) {
+        if (err.name === 'NotFound') return errorResponse(res, 404, 'File not found');
         throw err;
       }
-      await deleteObject({ Bucket, Key: key });
+      await deleteObject(client, { Bucket: bucketName, Key: key });
       return successResponse(res, { message: 'File deleted successfully', key });
     } catch (error) {
       console.error('API Delete error:', error);
@@ -306,6 +147,5 @@ module.exports = async function handler(req, res) {
     }
   }
 
-  // --- Not found ---
   return errorResponse(res, 404, 'Not found');
-}
+};

--- a/api/r2-client.js
+++ b/api/r2-client.js
@@ -1,15 +1,15 @@
 const { S3Client } = require('@aws-sdk/client-s3');
-const { 
-  PutObjectCommand, 
-  GetObjectCommand, 
-  DeleteObjectCommand, 
+const {
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
   ListObjectsV2Command,
   HeadObjectCommand
 } = require('@aws-sdk/client-s3');
 const { getSignedUrl } = require('@aws-sdk/s3-request-presigner');
 
-// Create R2 client
-const R2 = new S3Client({
+// Master client (from env) — used as fallback and for buckets.json storage
+const masterClient = new S3Client({
   region: 'auto',
   endpoint: process.env.R2_ENDPOINT,
   credentials: {
@@ -18,43 +18,84 @@ const R2 = new S3Client({
   },
 });
 
-// Helper functions
-async function putObject(params) {
-  const command = new PutObjectCommand(params);
-  return await R2.send(command);
+// Factory: create S3Client for any bucket config
+function createR2Client(bucketConfig) {
+  return new S3Client({
+    region: 'auto',
+    endpoint: bucketConfig.endpoint,
+    credentials: {
+      accessKeyId: bucketConfig.accessKeyId,
+      secretAccessKey: bucketConfig.secretAccessKey,
+    },
+  });
 }
 
-async function getObject(params) {
+// Resolve client + bucket name from request context
+// Priority: X-Bucket-ID header → master bucket
+async function resolveClientAndBucket(req) {
+  const bucketId = req.headers['x-bucket-id'];
+  if (bucketId) {
+    const { getBucketById } = require('./bucket-store');
+    const bucket = await getBucketById(bucketId);
+    if (!bucket) throw new Error(`Bucket not found: ${bucketId}`);
+    return {
+      client: createR2Client(bucket),
+      bucketName: bucket.name,
+      publicUrl: bucket.publicUrl || '',
+    };
+  }
+  // Fallback to master bucket
+  return {
+    client: masterClient,
+    bucketName: process.env.R2_BUCKET_NAME,
+    publicUrl: process.env.R2_PUBLIC_URL || '',
+  };
+}
+
+// Generic command helpers — accept explicit client
+async function putObject(client, params) {
+  return await client.send(new PutObjectCommand(params));
+}
+
+async function getObject(client, params) {
+  return await client.send(new GetObjectCommand(params));
+}
+
+async function deleteObject(client, params) {
+  return await client.send(new DeleteObjectCommand(params));
+}
+
+async function listObjects(client, params) {
+  return await client.send(new ListObjectsV2Command(params));
+}
+
+async function headObject(client, params) {
+  return await client.send(new HeadObjectCommand(params));
+}
+
+async function getPresignedUrl(client, params) {
   const command = new GetObjectCommand(params);
-  return await R2.send(command);
+  return await getSignedUrl(client, command, { expiresIn: params.expiresIn || 3600 });
 }
 
-async function deleteObject(params) {
-  const command = new DeleteObjectCommand(params);
-  return await R2.send(command);
-}
-
-async function listObjects(params) {
-  const command = new ListObjectsV2Command(params);
-  return await R2.send(command);
-}
-
-async function headObject(params) {
-  const command = new HeadObjectCommand(params);
-  return await R2.send(command);
-}
-
-async function getPresignedUrl(params) {
-  const command = new GetObjectCommand(params);
-  return await getSignedUrl(R2, command, { expiresIn: params.expiresIn || 3600 });
-}
+// Master-only helpers (for bucket-store internal use)
+const master = {
+  put: (params) => putObject(masterClient, params),
+  get: (params) => getObject(masterClient, params),
+  delete: (params) => deleteObject(masterClient, params),
+  list: (params) => listObjects(masterClient, params),
+  head: (params) => headObject(masterClient, params),
+};
 
 module.exports = {
-  R2,
+  masterClient,
+  createR2Client,
+  resolveClientAndBucket,
   putObject,
   getObject,
   deleteObject,
   listObjects,
   headObject,
-  getPresignedUrl
+  getPresignedUrl,
+  master,
 };

--- a/api/r2.js
+++ b/api/r2.js
@@ -121,7 +121,7 @@ module.exports = async function handler(req, res) {
       const files = await Promise.all((result.Contents || []).map(async obj => {
         const url = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${obj.Key}` : null;
         let presignedUrl = null;
-        try { presignedUrl = await getPresignedUrl(client, { Bucket: bucketName, Key: obj.Key, expiresIn: 3600 }); } catch (e) {}
+        try { presignedUrl = await getPresignedUrl(client, { Bucket: bucketName, Key: obj.Key, expiresIn: 604800 }); } catch (e) {}
         return { key: obj.Key, filename: obj.Key, size: obj.Size, lastModified: obj.LastModified, contentType: mimeFromKey(obj.Key), url, presignedUrl, downloadUrl: `/r2/download/${encodeURIComponent(obj.Key)}` };
       }));
       return successResponse(res, { files, pagination: { nextToken: result.NextContinuationToken || null, isTruncated: result.IsTruncated || false, count: files.length } });

--- a/api/r2.js
+++ b/api/r2.js
@@ -1,71 +1,69 @@
 const formidable = require('formidable');
 const { authenticateToken, handleCors, errorResponse, successResponse, setCookie } = require('./utils');
-// Only allow JWT session authentication for this endpoint
-function authenticateJwtOnly(req) {
-  return authenticateToken(req);
-}
-const { putObject, listObjects, headObject, getObject, deleteObject, getPresignedUrl } = require('./r2-client');
+const { resolveClientAndBucket, putObject, listObjects, headObject, getObject, deleteObject, getPresignedUrl } = require('./r2-client');
 
-// Helper: get key from req
 function getKey(req) {
   if (req.query && req.query.key) return req.query.key;
-  if (req.query && req.query["[key]"]) return req.query["[key]"];
-  if (req.url && req.url.match(/\/([^\/]+)$/)) return decodeURIComponent(req.url.match(/\/([^\/]+)$/)[1]);
+  if (req.url && req.url.match(/\/([^/]+)$/)) return decodeURIComponent(req.url.match(/\/([^/]+)$/)[1]);
   return null;
+}
+
+const MIME_MAP = {
+  jpg:'image/jpeg',jpeg:'image/jpeg',png:'image/png',gif:'image/gif',webp:'image/webp',svg:'image/svg+xml',bmp:'image/bmp',ico:'image/x-icon',
+  mp4:'video/mp4',avi:'video/x-msvideo',mov:'video/quicktime',wmv:'video/x-ms-wmv',flv:'video/x-flv',webm:'video/webm',mkv:'video/x-matroska',
+  mp3:'audio/mpeg',wav:'audio/wav',ogg:'audio/ogg',aac:'audio/aac',flac:'audio/flac',m4a:'audio/mp4',
+  pdf:'application/pdf',doc:'application/msword',docx:'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  xls:'application/vnd.ms-excel',xlsx:'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  txt:'text/plain',html:'text/html',css:'text/css',js:'application/javascript',json:'application/json',xml:'application/xml',csv:'text/csv',
+  zip:'application/zip',rar:'application/vnd.rar','7z':'application/x-7z-compressed',tar:'application/x-tar',gz:'application/gzip',
+};
+
+function mimeFromKey(key) {
+  return MIME_MAP[key.toLowerCase().split('.').pop()] || 'application/octet-stream';
 }
 
 module.exports = async function handler(req, res) {
   if (handleCors(req, res)) return;
 
-  // --- Upload file (POST /r2/upload) ---
+  let ctx;
+  try {
+    ctx = await resolveClientAndBucket(req);
+  } catch (err) {
+    return errorResponse(res, 400, err.message);
+  }
+  const { client, bucketName, publicUrl: baseUrl } = ctx;
+
+  // --- Upload (POST /r2/upload) ---
   if (req.method === 'POST' && req.url === '/r2/upload') {
     try {
-      const { user, newAccessToken } = authenticateJwtOnly(req);
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
+      const { newAccessToken } = require('./utils').authenticateToken(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
       const form = new formidable.IncomingForm({ maxFileSize: 25 * 1024 * 1024, maxFiles: 1 });
       const [fields, files] = await form.parse(req);
-      if (!files.file || files.file.length === 0) return errorResponse(res, 400, 'No file uploaded');
+      if (!files.file?.length) return errorResponse(res, 400, 'No file uploaded');
       const file = Array.isArray(files.file) ? files.file[0] : files.file;
-      if (!file.size || file.size === 0) return errorResponse(res, 400, 'Empty file uploaded');
-      const originalName = file.originalFilename || file.name || 'unknown';
-      let filename = originalName;
+      if (!file.size) return errorResponse(res, 400, 'Empty file uploaded');
+
       const fs = require('fs');
+      const originalName = file.originalFilename || 'unknown';
       let fileBuffer = fs.readFileSync(file.filepath);
       let contentType = file.mimetype || 'application/octet-stream';
-      
-      // Auto-convert to WebP if image
-      if (contentType.startsWith('image/') && !contentType.includes('webp') && !contentType.includes('svg') && !contentType.includes('gif')) {
+      let filename = originalName;
+
+      if (contentType.startsWith('image/') && !['webp','svg','gif'].some(t => contentType.includes(t))) {
         try {
           const sharp = require('sharp');
-          const convertedBuffer = await sharp(fileBuffer)
-            .webp({ quality: 80 })
-            .toBuffer();
-            
-          fileBuffer = convertedBuffer;
+          fileBuffer = await sharp(fileBuffer).webp({ quality: 80 }).toBuffer();
           contentType = 'image/webp';
-          
-          const nameParts = originalName.split('.');
-          const nameWithoutExt = nameParts.length > 1 ? nameParts.slice(0, -1).join('.') : originalName;
-          filename = `${nameWithoutExt}.webp`;
-          console.log(`Auto-converted ${originalName} to ${filename}`);
-        } catch (e) {
-          console.error('Auto-conversion failed:', e);
-        }
+          const base = originalName.split('.').slice(0, -1).join('.') || originalName;
+          filename = `${base}.webp`;
+        } catch (e) { console.error('Auto-convert failed:', e); }
       }
 
-      await putObject({ Bucket: process.env.R2_BUCKET_NAME, Key: filename, Body: fileBuffer, ContentType: contentType });
-      const baseUrl = process.env.R2_PUBLIC_URL || '';
-      const publicUrl = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${filename}` : null;
-      // Samakan response dengan /api/files/upload: data: { file: {...} }
-      return require('./utils').successResponse(
-        res,
-        { file: { filename, key: filename, size: file.size, contentType: file.mimetype || 'application/octet-stream', url: publicUrl, downloadUrl: `/r2/download/${filename}` } },
-        'File uploaded successfully'
-      );
+      await putObject(client, { Bucket: bucketName, Key: filename, Body: fileBuffer, ContentType: contentType });
+      const url = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${filename}` : null;
+      return successResponse(res, { file: { filename, key: filename, size: file.size, contentType, url, downloadUrl: `/r2/download/${filename}` } }, 'File uploaded successfully');
     } catch (error) {
       console.error('R2 Upload error:', error);
       if (error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
@@ -73,91 +71,38 @@ module.exports = async function handler(req, res) {
     }
   }
 
-  // --- Upload & Convert to WebP (POST /r2/upload-webp) ---
+  // --- Upload WebP (POST /r2/upload-webp) ---
   if (req.method === 'POST' && req.url === '/r2/upload-webp') {
     try {
-      const { user, newAccessToken } = authenticateJwtOnly(req);
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
+      const { newAccessToken } = require('./utils').authenticateToken(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
       const form = new formidable.IncomingForm({ maxFileSize: 10 * 1024 * 1024, maxFiles: 1 });
       const [fields, files] = await form.parse(req);
-      
-      if (!files.image || files.image.length === 0) return errorResponse(res, 400, 'No image file uploaded');
+      if (!files.image?.length) return errorResponse(res, 400, 'No image uploaded');
       const file = Array.isArray(files.image) ? files.image[0] : files.image;
-      if (!file.size || file.size === 0) return errorResponse(res, 400, 'Empty file uploaded');
-      
-      // Check if file is an image
-      if (!file.mimetype || !file.mimetype.startsWith('image/')) {
-        return errorResponse(res, 400, 'Only image files are allowed');
-      }
-      
-      const sharp = require('sharp');
+      if (!file.size) return errorResponse(res, 400, 'Empty file uploaded');
+      if (!file.mimetype?.startsWith('image/')) return errorResponse(res, 400, 'Only image files allowed');
+
       const fs = require('fs');
-      const originalName = file.originalFilename || file.name || 'unknown';
-      const originalSize = file.size; // Store original file size
+      const sharp = require('sharp');
+      const originalName = file.originalFilename || 'unknown';
       const quality = parseInt(fields.quality?.[0] || fields.quality || 80, 10);
-      
       let fileBuffer = fs.readFileSync(file.filepath);
-      let fileName = originalName;
-      let contentType = 'image/webp';
       let wasConverted = false;
+      let fileName = originalName;
 
-      // Check if file is already WebP
       if (file.mimetype !== 'image/webp') {
-        console.log(`Converting ${fileName} to WebP format...`);
-        
-        // Convert to WebP
-        try {
-          fileBuffer = await sharp(fileBuffer).webp({ quality }).toBuffer();
-          wasConverted = true;
-          
-          // Update filename to have .webp extension
-          const nameWithoutExt = fileName.substring(0, fileName.lastIndexOf('.')) || fileName;
-          fileName = `${nameWithoutExt}.webp`;
-        } catch (convertError) {
-          console.error('WebP conversion error:', convertError);
-          return errorResponse(res, 500, 'Failed to convert image to WebP', convertError.message);
-        }
+        fileBuffer = await sharp(fileBuffer).webp({ quality }).toBuffer();
+        wasConverted = true;
+        const base = fileName.substring(0, fileName.lastIndexOf('.')) || fileName;
+        fileName = `${base}.webp`;
       }
 
-      // Generate unique filename with timestamp
-      const timestamp = Date.now();
-      const uniqueFileName = `webp/${timestamp}-${fileName}`;
-
-      // Upload to R2
-      await putObject({ 
-        Bucket: process.env.R2_BUCKET_NAME, 
-        Key: uniqueFileName, 
-        Body: fileBuffer, 
-        ContentType: contentType 
-      });
-      
-      const baseUrl = process.env.R2_PUBLIC_URL || '';
-      const publicUrl = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${uniqueFileName}` : null;
-      
-      return successResponse(
-        res,
-        {
-          file: {
-            key: uniqueFileName,
-            originalName: originalName,
-            convertedName: fileName,
-            filename: uniqueFileName,
-            size: fileBuffer.length,
-            originalSize: originalSize,
-            contentType: contentType,
-            url: publicUrl,
-            downloadUrl: `/r2/download/${uniqueFileName}`,
-            wasConverted: wasConverted,
-            originalFormat: file.mimetype,
-            uploadedAt: new Date().toISOString()
-          }
-        },
-        'Image uploaded and converted successfully'
-      );
+      const uniqueKey = `webp/${Date.now()}-${fileName}`;
+      await putObject(client, { Bucket: bucketName, Key: uniqueKey, Body: fileBuffer, ContentType: 'image/webp' });
+      const url = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${uniqueKey}` : null;
+      return successResponse(res, { file: { key: uniqueKey, filename: uniqueKey, originalName, convertedName: fileName, size: fileBuffer.length, originalSize: file.size, contentType: 'image/webp', url, downloadUrl: `/r2/download/${uniqueKey}`, wasConverted, originalFormat: file.mimetype, uploadedAt: new Date().toISOString() } }, 'Image uploaded and converted successfully');
     } catch (error) {
       console.error('R2 WebP Upload error:', error);
       if (error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
@@ -168,146 +113,72 @@ module.exports = async function handler(req, res) {
   // --- List files (GET /r2/files) ---
   if (req.method === 'GET' && req.url.startsWith('/r2/files')) {
     try {
-      const { user, newAccessToken } = authenticateJwtOnly(req);
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
+      const { newAccessToken } = require('./utils').authenticateToken(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
       const { token, prefix, limit } = req.query;
-      const Bucket = process.env.R2_BUCKET_NAME;
-      if (!Bucket) return errorResponse(res, 500, 'Server configuration error: Bucket name is missing.');
-      const result = await listObjects({ Bucket, ContinuationToken: token || undefined, Prefix: prefix || '', MaxKeys: parseInt(limit, 10) || 100 });
-      const baseUrl = process.env.R2_PUBLIC_URL || '';
+      const result = await listObjects(client, { Bucket: bucketName, ContinuationToken: token || undefined, Prefix: prefix || '', MaxKeys: parseInt(limit, 10) || 100 });
       const files = await Promise.all((result.Contents || []).map(async obj => {
-        const publicUrl = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${obj.Key}` : null;
+        const url = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${obj.Key}` : null;
         let presignedUrl = null;
-        try {
-          presignedUrl = await getPresignedUrl ? await getPresignedUrl({
-            Bucket,
-            Key: obj.Key,
-            expiresIn: 3600
-          }) : null;
-        } catch (e) {
-          presignedUrl = null;
-        }
-        // getContentTypeFromKey logic (inline, match files.js)
-        const ext = obj.Key.toLowerCase().split('.').pop();
-        const mimeTypes = {
-          'jpg': 'image/jpeg','jpeg': 'image/jpeg','png': 'image/png','gif': 'image/gif','webp': 'image/webp','svg': 'image/svg+xml','bmp': 'image/bmp','ico': 'image/x-icon',
-          'mp4': 'video/mp4','avi': 'video/x-msvideo','mov': 'video/quicktime','wmv': 'video/x-ms-wmv','flv': 'video/x-flv','webm': 'video/webm','mkv': 'video/x-matroska',
-          'mp3': 'audio/mpeg','wav': 'audio/wav','ogg': 'audio/ogg','aac': 'audio/aac','flac': 'audio/flac','m4a': 'audio/mp4',
-          'pdf': 'application/pdf','doc': 'application/msword','docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document','xls': 'application/vnd.ms-excel','xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet','ppt': 'application/vnd.ms-powerpoint','pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation','txt': 'text/plain','html': 'text/html','css': 'text/css','js': 'application/javascript','json': 'application/json','xml': 'application/xml','csv': 'text/csv',
-          'zip': 'application/zip','rar': 'application/vnd.rar','7z': 'application/x-7z-compressed','tar': 'application/x-tar','gz': 'application/gzip'
-        };
-        const contentType = mimeTypes[ext] || 'application/octet-stream';
-        return {
-          key: obj.Key,
-          filename: obj.Key,
-          size: obj.Size,
-          lastModified: obj.LastModified,
-          contentType,
-          url: publicUrl,
-          presignedUrl,
-          downloadUrl: `/r2/download/${encodeURIComponent(obj.Key)}`
-        };
+        try { presignedUrl = await getPresignedUrl(client, { Bucket: bucketName, Key: obj.Key, expiresIn: 3600 }); } catch (e) {}
+        return { key: obj.Key, filename: obj.Key, size: obj.Size, lastModified: obj.LastModified, contentType: mimeFromKey(obj.Key), url, presignedUrl, downloadUrl: `/r2/download/${encodeURIComponent(obj.Key)}` };
       }));
-      return require('./utils').successResponse(res, { files, pagination: { nextToken: result.NextContinuationToken || null, isTruncated: result.IsTruncated || false, count: files.length } });
+      return successResponse(res, { files, pagination: { nextToken: result.NextContinuationToken || null, isTruncated: result.IsTruncated || false, count: files.length } });
     } catch (error) {
-      console.error('R2 List files error:', error);
+      console.error('R2 List error:', error);
       if (error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
       return errorResponse(res, 500, 'Failed to list files', error.message);
     }
   }
 
-  // --- Download file (GET /r2/download/:key) ---
+  // --- Download (GET /r2/download/:key) ---
   if (req.method === 'GET' && req.url.startsWith('/r2/download/')) {
     try {
-      const { user, newAccessToken } = authenticateJwtOnly(req);
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
-      // Parse URL to extract file key, support /r2/download/:key or ?key=
+      const { newAccessToken } = require('./utils').authenticateToken(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
       const { parse } = require('url');
       const { pathname, query } = parse(req.url, true);
-      let key = query.key || pathname.replace('/r2/download/', '');
+      const key = decodeURIComponent(query.key || pathname.replace('/r2/download/', ''));
       if (!key) return errorResponse(res, 400, 'File key is required');
-      const decodedKey = decodeURIComponent(key);
-      const Bucket = process.env.R2_BUCKET_NAME;
-      if (!Bucket) return errorResponse(res, 500, 'Server configuration error: Bucket name is missing.');
-      // Stream file from R2 directly to force download
-      const headResult = await headObject({ Bucket, Key: decodedKey });
-      if (!headResult) return errorResponse(res, 404, 'File not found');
-      try {
-        const result = await getObject({ Bucket, Key: decodedKey });
-        const originalName = decodedKey.includes('-') ? decodedKey.substring(decodedKey.indexOf('-') + 1) : decodedKey;
-        
-        // Set headers
-        res.setHeader('Content-Type', headResult.ContentType || result.ContentType || 'application/octet-stream');
-        res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(originalName)}"`);
-        if (headResult.ContentLength || result.ContentLength) {
-          res.setHeader('Content-Length', headResult.ContentLength || result.ContentLength);
-        }
 
-        // Handle streaming appropriately
-        if (result.Body && typeof result.Body.pipe === 'function') {
-          // Use event handlers to properly handle end and error cases
-          result.Body.on('error', (err) => {
-            console.error('Stream error:', err);
-            // Only end response if it hasn't been sent yet
-            if (!res.headersSent) {
-              res.status(500).end();
-            }
-          });
-          
-          // Stream to response
-          return result.Body.pipe(res);
-        } else if (result.Body) {
-          // Buffer approach when pipe not available
-          const chunks = [];
-          for await (const chunk of result.Body) { 
-            chunks.push(chunk); 
-          }
-          const buffer = Buffer.concat(chunks);
-          return res.end(buffer);
-        } else {
-          throw new Error('No file content received');
-        }
-      } catch (streamError) {
-        console.error('R2 streaming error:', streamError);
-        if (!res.headersSent) {
-          return errorResponse(res, 500, 'Failed to stream file', streamError.message);
-        }
+      const headResult = await headObject(client, { Bucket: bucketName, Key: key });
+      const result = await getObject(client, { Bucket: bucketName, Key: key });
+      const originalName = key.includes('-') ? key.substring(key.indexOf('-') + 1) : key;
+
+      res.setHeader('Content-Type', headResult.ContentType || 'application/octet-stream');
+      res.setHeader('Content-Disposition', `attachment; filename="${encodeURIComponent(originalName)}"`);
+      if (headResult.ContentLength) res.setHeader('Content-Length', headResult.ContentLength);
+
+      if (result.Body && typeof result.Body.pipe === 'function') {
+        result.Body.on('error', () => { if (!res.headersSent) res.status(500).end(); });
+        return result.Body.pipe(res);
       }
+      const chunks = [];
+      for await (const chunk of result.Body) chunks.push(chunk);
+      return res.end(Buffer.concat(chunks));
     } catch (error) {
       console.error('R2 Download error:', error);
       if (error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
-      if (error.name === 'NoSuchKey' || error.message.includes('not found')) return errorResponse(res, 404, 'File not found');
+      if (error.name === 'NoSuchKey') return errorResponse(res, 404, 'File not found');
       return errorResponse(res, 500, 'Failed to download file', error.message);
     }
   }
 
-  // --- Delete file (DELETE /r2/files/:key) ---
+  // --- Delete (DELETE /r2/files/:key) ---
   if (req.method === 'DELETE' && req.url.startsWith('/r2/files/')) {
     try {
-      const { user, newAccessToken } = authenticateJwtOnly(req);
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
+      const { newAccessToken } = require('./utils').authenticateToken(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
       const key = getKey(req);
       if (!key) return errorResponse(res, 400, 'File key is required');
-      const Bucket = process.env.R2_BUCKET_NAME;
-      try {
-        await headObject({ Bucket, Key: key });
-      } catch (err) {
-        if (err.name === 'NotFound' || err.message.includes('not found')) return errorResponse(res, 404, 'File not found');
+      try { await headObject(client, { Bucket: bucketName, Key: key }); } catch (err) {
+        if (err.name === 'NotFound') return errorResponse(res, 404, 'File not found');
         throw err;
       }
-      await deleteObject({ Bucket, Key: key });
+      await deleteObject(client, { Bucket: bucketName, Key: key });
       return res.json({ message: 'File deleted successfully' });
     } catch (error) {
       console.error('R2 Delete error:', error);
@@ -319,28 +190,21 @@ module.exports = async function handler(req, res) {
   // --- Presigned URL (GET /r2/presigned/:key) ---
   if (req.method === 'GET' && req.url.startsWith('/r2/presigned/')) {
     try {
-      const { user, newAccessToken } = authenticateJwtOnly(req);
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
+      const { newAccessToken } = require('./utils').authenticateToken(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
       const key = getKey(req);
-      const expires = req.query && req.query.expires ? req.query.expires : undefined;
       if (!key) return errorResponse(res, 400, 'File key is required');
-      const Bucket = process.env.R2_BUCKET_NAME;
-      const headResult = await headObject({ Bucket, Key: key });
-      if (!headResult) return errorResponse(res, 404, 'File not found');
-      const expiresIn = parseInt(expires, 10) || 3600;
-      const url = await getPresignedUrl({ Bucket, Key: key, expiresIn });
+      await headObject(client, { Bucket: bucketName, Key: key });
+      const expiresIn = parseInt(req.query?.expires, 10) || 3600;
+      const url = await getPresignedUrl(client, { Bucket: bucketName, Key: key, expiresIn });
       return successResponse(res, { url, expiresIn });
     } catch (error) {
-      console.error('R2 Presigned URL error:', error);
+      console.error('R2 Presigned error:', error);
       if (error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
       return errorResponse(res, 500, 'Failed to generate presigned URL', error.message);
     }
   }
 
-  // --- Not found ---
   return errorResponse(res, 404, 'Not found');
-}
+};

--- a/api/stats.js
+++ b/api/stats.js
@@ -78,5 +78,25 @@ module.exports = async function handler(req, res) {
     }
   }
 
+  // GET /api/stats/count — lightweight total file count (loops all pages, no presigned URLs)
+  if (req.method === 'GET' && req.url === '/stats/count') {
+    try {
+      const { newAccessToken } = authenticateHybrid(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
+      let totalFiles = 0, nextToken = null;
+      do {
+        const result = await listObjects(client, { Bucket: bucketName, ContinuationToken: nextToken, MaxKeys: 1000 });
+        totalFiles += (result.Contents || []).length;
+        nextToken = result.NextContinuationToken;
+      } while (nextToken);
+
+      return successResponse(res, { totalFiles }, 'Count retrieved');
+    } catch (error) {
+      if (error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
+      return errorResponse(res, 500, 'Failed to count files');
+    }
+  }
+
   return errorResponse(res, 404, 'Not found');
 };

--- a/api/stats.js
+++ b/api/stats.js
@@ -1,169 +1,82 @@
-const { authenticateHybrid, handleCors, errorResponse, successResponse } = require('./utils');
-const { listObjects } = require('./r2-client');
+const { authenticateHybrid, handleCors, errorResponse, successResponse, setCookie } = require('./utils');
+const { resolveClientAndBucket, listObjects } = require('./r2-client');
+
+function formatBytes(bytes) {
+  if (bytes === 0) return '0 Bytes';
+  const k = 1024, sizes = ['Bytes','KB','MB','GB','TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+}
 
 module.exports = async function handler(req, res) {
   if (handleCors(req, res)) return;
 
-  // Test endpoint
   if (req.method === 'GET' && req.url === '/stats/test') {
     return successResponse(res, { message: 'Stats API is working' }, 'Test successful');
   }
 
-  // --- Get Storage Statistics (GET /api/stats/storage) ---
+  let ctx;
+  try {
+    ctx = await resolveClientAndBucket(req);
+  } catch (err) {
+    return errorResponse(res, 400, err.message);
+  }
+  const { client, bucketName } = ctx;
+
+  // GET /api/stats/storage
   if (req.method === 'GET' && req.url === '/stats/storage') {
     try {
-      const { user, newAccessToken } = authenticateHybrid(req);
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
+      const { newAccessToken } = authenticateHybrid(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
 
-      const Bucket = process.env.R2_BUCKET_NAME;
-      if (!Bucket) return errorResponse(res, 500, 'Server configuration error: Bucket name is missing.');
-
-      let totalSize = 0;
-      let totalFiles = 0;
-      let fileTypes = {};
-      let largestFiles = [];
-      let nextToken = null;
-
-      // Iterate through all objects to calculate total size
+      let totalSize = 0, totalFiles = 0, fileTypes = {}, largestFiles = [], nextToken = null;
       do {
-        const result = await listObjects({ 
-          Bucket, 
-          ContinuationToken: nextToken,
-          MaxKeys: 1000 // Get more files per request for efficiency
-        });
-
-        if (result.Contents) {
-          for (const obj of result.Contents) {
-            totalSize += obj.Size;
-            totalFiles++;
-
-            // Track file types
-            const ext = obj.Key.toLowerCase().split('.').pop();
-            fileTypes[ext] = (fileTypes[ext] || 0) + 1;
-
-            // Track largest files (keep top 10)
-            largestFiles.push({
-              key: obj.Key,
-              size: obj.Size,
-              lastModified: obj.LastModified
-            });
-          }
+        const result = await listObjects(client, { Bucket: bucketName, ContinuationToken: nextToken, MaxKeys: 1000 });
+        for (const obj of result.Contents || []) {
+          totalSize += obj.Size; totalFiles++;
+          const ext = obj.Key.toLowerCase().split('.').pop();
+          fileTypes[ext] = (fileTypes[ext] || 0) + 1;
+          largestFiles.push({ key: obj.Key, size: obj.Size, lastModified: obj.LastModified });
         }
-
         nextToken = result.NextContinuationToken;
       } while (nextToken);
 
-      // Sort and limit largest files to top 10
       largestFiles.sort((a, b) => b.size - a.size);
-      largestFiles = largestFiles.slice(0, 10);
+      largestFiles = largestFiles.slice(0, 10).map(f => ({ ...f, sizeFormatted: formatBytes(f.size) }));
 
-      // Calculate limits and usage percentages
-      const freeTierLimits = {
-        storage: 10 * 1024 * 1024 * 1024, // 10 GB in bytes
-        requests: 100000, // 100k requests per month (we can't track this from R2 directly)
-        bandwidth: 100 * 1024 * 1024 * 1024 // 100 GB in bytes (we can't track this from R2 directly)
-      };
+      const freeTierLimit = 10 * 1024 * 1024 * 1024;
+      const usagePercent = (totalSize / freeTierLimit) * 100;
 
-      const storageUsagePercent = (totalSize / freeTierLimits.storage) * 100;
-
-      const stats = {
-        storage: {
-          totalSize,
-          totalSizeFormatted: formatBytes(totalSize),
-          totalFiles,
-          freeTierLimit: freeTierLimits.storage,
-          freeTierLimitFormatted: formatBytes(freeTierLimits.storage),
-          usagePercent: Math.round(storageUsagePercent * 100) / 100,
-          remainingSize: freeTierLimits.storage - totalSize,
-          remainingSizeFormatted: formatBytes(freeTierLimits.storage - totalSize),
-          isNearLimit: storageUsagePercent > 80,
-          isOverLimit: storageUsagePercent > 100
-        },
-        fileTypes,
-        largestFiles: largestFiles.map(file => ({
-          ...file,
-          sizeFormatted: formatBytes(file.size)
-        })),
-        lastUpdated: new Date().toISOString(),
-        note: "Traffic and request statistics are not available through R2 API. Please check your Cloudflare dashboard for complete usage metrics."
-      };
-
-      return successResponse(res, stats, 'Storage statistics retrieved successfully');
-
+      return successResponse(res, {
+        storage: { totalSize, totalSizeFormatted: formatBytes(totalSize), totalFiles, freeTierLimit, freeTierLimitFormatted: formatBytes(freeTierLimit), usagePercent: Math.round(usagePercent * 100) / 100, remainingSize: freeTierLimit - totalSize, remainingSizeFormatted: formatBytes(freeTierLimit - totalSize), isNearLimit: usagePercent > 80, isOverLimit: usagePercent > 100 },
+        fileTypes, largestFiles, lastUpdated: new Date().toISOString(),
+        note: 'Traffic and request statistics are not available through R2 API.'
+      }, 'Storage statistics retrieved successfully');
     } catch (error) {
       console.error('Stats error:', error);
-      if (error.message.includes('token') || error.message.includes('authenticate')) {
-        return errorResponse(res, 401, error.message);
-      }
+      if (error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
       return errorResponse(res, 500, 'Failed to retrieve statistics', error.message);
     }
   }
 
-  // --- Get Quick Stats (GET /api/stats/quick) ---
+  // GET /api/stats/quick
   if (req.method === 'GET' && req.url === '/stats/quick') {
     try {
-      const { user, newAccessToken } = authenticateHybrid(req);
-      if (newAccessToken) {
-        const { setCookie } = require('./utils');
-        const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-        res.setHeader('Set-Cookie', accessCookie);
-      }
+      const { newAccessToken } = authenticateHybrid(req);
+      if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
 
-      const Bucket = process.env.R2_BUCKET_NAME;
-      if (!Bucket) return errorResponse(res, 500, 'Server configuration error: Bucket name is missing.');
+      const result = await listObjects(client, { Bucket: bucketName, MaxKeys: 1000 });
+      let totalSize = 0, totalFiles = 0;
+      for (const obj of result.Contents || []) { totalSize += obj.Size; totalFiles++; }
 
-      // Get first 1000 files to give a quick estimate
-      const result = await listObjects({ 
-        Bucket, 
-        MaxKeys: 1000 
-      });
-
-      let totalSize = 0;
-      let totalFiles = 0;
-
-      if (result.Contents) {
-        for (const obj of result.Contents) {
-          totalSize += obj.Size;
-          totalFiles++;
-        }
-      }
-
-      const freeTierLimit = 10 * 1024 * 1024 * 1024; // 10 GB
-      const usagePercent = (totalSize / freeTierLimit) * 100;
-
-      const quickStats = {
-        totalSize,
-        totalSizeFormatted: formatBytes(totalSize),
-        totalFiles,
-        usagePercent: Math.round(usagePercent * 100) / 100,
-        isEstimate: result.IsTruncated || false,
-        estimateNote: result.IsTruncated ? "This is an estimate based on first 1000 files. Use /stats/storage for complete data." : null,
-        lastUpdated: new Date().toISOString()
-      };
-
-      return successResponse(res, quickStats, 'Quick statistics retrieved successfully');
-
+      const freeTierLimit = 10 * 1024 * 1024 * 1024;
+      return successResponse(res, { totalSize, totalSizeFormatted: formatBytes(totalSize), totalFiles, usagePercent: Math.round((totalSize / freeTierLimit) * 10000) / 100, isEstimate: result.IsTruncated || false, lastUpdated: new Date().toISOString() }, 'Quick statistics retrieved successfully');
     } catch (error) {
       console.error('Quick stats error:', error);
-      if (error.message.includes('token') || error.message.includes('authenticate')) {
-        return errorResponse(res, 401, error.message);
-      }
+      if (error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
       return errorResponse(res, 500, 'Failed to retrieve quick statistics', error.message);
     }
   }
 
   return errorResponse(res, 404, 'Not found');
 };
-
-// Helper function to format bytes
-function formatBytes(bytes) {
-  if (bytes === 0) return '0 Bytes';
-  const k = 1024;
-  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
-  const i = Math.floor(Math.log(bytes) / Math.log(k));
-  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
-}

--- a/api/upload-multiple.js
+++ b/api/upload-multiple.js
@@ -1,134 +1,59 @@
 const formidable = require('formidable');
-const { 
-  authenticateHybrid, 
-  handleCors, 
-  errorResponse, 
-  successResponse 
-} = require('./utils');
-const { putObject } = require('./r2-client');
+const { authenticateHybrid, handleCors, errorResponse, successResponse, setCookie } = require('./utils');
+const { resolveClientAndBucket, putObject } = require('./r2-client');
 
 module.exports = async function handler(req, res) {
   if (handleCors(req, res)) return;
-
-  if (req.method !== 'POST') {
-    return errorResponse(res, 405, 'Method not allowed');
-  }
+  if (req.method !== 'POST') return errorResponse(res, 405, 'Method not allowed');
 
   try {
-    // Authenticate using hybrid authentication (supports both API key and JWT session)
-    const { user, newAccessToken } = authenticateHybrid(req);
-    
-    // Set new access token if JWT was refreshed
-    if (newAccessToken) {
-      const { setCookie } = require('./utils');
-      const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-      res.setHeader('Set-Cookie', accessCookie);
-    }
-    
-    // Parse form data
-    const form = new formidable.IncomingForm({
-      maxFileSize: 4 * 1024 * 1024, // 4MB for Vercel Hobby compatibility  
-      maxFiles: 10
-    });
-    
-    const [fields, files] = await form.parse(req);
-    
-    if (!files.files || files.files.length === 0) {
-      return errorResponse(res, 400, 'No files uploaded', 'Please provide files in the "files" field');
-    }
-    
+    const { newAccessToken } = authenticateHybrid(req);
+    if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
+    const { client, bucketName, publicUrl: baseUrl } = await resolveClientAndBucket(req);
+
+    const form = new formidable.IncomingForm({ maxFileSize: 4 * 1024 * 1024, maxFiles: 10 });
+    const [, files] = await form.parse(req);
+    if (!files.files?.length) return errorResponse(res, 400, 'No files uploaded');
+
     const fileArray = Array.isArray(files.files) ? files.files : [files.files];
-    const uploadResults = [];
+    const uploaded = [];
     const errors = [];
-    
+
     for (const file of fileArray) {
       try {
-        // Validate file
-        if (!file.size || file.size === 0) {
-          errors.push({ file: file.originalFilename || file.name, error: 'Empty file' });
-          continue;
-        }
-        
-        // Generate filename with timestamp and random suffix
-        const timestamp = Date.now();
-        const randomSuffix = Math.random().toString(36).substring(2, 8);
-        const originalName = file.originalFilename || file.name || 'unknown';
-        const filename = `${timestamp}-${randomSuffix}-${originalName}`;
-        
-        // Read file buffer
+        if (!file.size) { errors.push({ file: file.originalFilename, error: 'Empty file' }); continue; }
+
         const fs = require('fs');
+        const timestamp = Date.now();
+        const rand = Math.random().toString(36).substring(2, 8);
+        const originalName = file.originalFilename || 'unknown';
         let fileBuffer = fs.readFileSync(file.filepath);
-
-        // Check if file is an image and not already WebP
         let contentType = file.mimetype || 'application/octet-stream';
-        let fileKey = filename;
+        let fileKey = `${timestamp}-${rand}-${originalName}`;
 
-        if (contentType.startsWith('image/') && !contentType.includes('webp') && !contentType.includes('svg') && !contentType.includes('gif')) {
+        if (contentType.startsWith('image/') && !['webp','svg','gif'].some(t => contentType.includes(t))) {
           try {
             const sharp = require('sharp');
-            const convertedBuffer = await sharp(fileBuffer)
-              .webp({ quality: 80 })
-              .toBuffer();
-             
-            fileBuffer = convertedBuffer;
+            fileBuffer = await sharp(fileBuffer).webp({ quality: 80 }).toBuffer();
             contentType = 'image/webp';
-            
-            // Update filename extension to .webp
-            const nameParts = originalName.split('.');
-            const nameWithoutExt = nameParts.length > 1 ? nameParts.slice(0, -1).join('.') : originalName;
-            const newOriginalName = `${nameWithoutExt}.webp`;
-            fileKey = `${timestamp}-${randomSuffix}-${newOriginalName}`;
-          } catch (conversionError) {
-             console.error('Image conversion failed, uploading original:', conversionError);
-          }
+            const base = originalName.split('.').slice(0, -1).join('.') || originalName;
+            fileKey = `${timestamp}-${rand}-${base}.webp`;
+          } catch (e) { console.error('Conversion failed:', e); }
         }
-        
-        // Upload to R2
-        await putObject({
-          Bucket: process.env.R2_BUCKET_NAME,
-          Key: fileKey,
-          Body: fileBuffer,
-          ContentType: contentType,
-        });
-        
-        // Build file URLs
-        const baseUrl = process.env.R2_PUBLIC_URL || '';
+
+        await putObject(client, { Bucket: bucketName, Key: fileKey, Body: fileBuffer, ContentType: contentType });
         const publicUrl = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${fileKey}` : null;
-        const downloadUrl = `/r2/download/${fileKey}`;
-        
-        uploadResults.push({
-          filename: fileKey,
-          originalName: originalName,
-          key: fileKey,
-          size: fileBuffer.length,
-          contentType: contentType,
-          publicUrl: publicUrl,
-          downloadUrl: downloadUrl,
-          uploadedAt: new Date().toISOString()
-        });
-      } catch (uploadError) {
-        errors.push({ 
-          file: file.originalFilename || file.name, 
-          error: uploadError.message 
-        });
+        uploaded.push({ filename: fileKey, originalName, key: fileKey, size: fileBuffer.length, contentType, publicUrl, downloadUrl: `/r2/download/${fileKey}`, uploadedAt: new Date().toISOString() });
+      } catch (e) {
+        errors.push({ file: file.originalFilename, error: e.message });
       }
     }
-    
-    return successResponse(res, {
-      uploaded: uploadResults,
-      errors: errors,
-      summary: {
-        total: fileArray.length,
-        successful: uploadResults.length,
-        failed: errors.length
-      }
-    }, `${uploadResults.length} files uploaded successfully${errors.length > 0 ? `, ${errors.length} failed` : ''}`);
-    
+
+    return successResponse(res, { uploaded, errors, summary: { total: fileArray.length, successful: uploaded.length, failed: errors.length } }, `${uploaded.length} files uploaded successfully${errors.length ? `, ${errors.length} failed` : ''}`);
   } catch (error) {
     console.error('API Multiple upload error:', error);
-    if (error.message.includes('API key') || error.message.includes('token') || error.message.includes('authenticate')) {
-      return errorResponse(res, 401, error.message);
-    }
+    if (error.message.includes('API key') || error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
     return errorResponse(res, 500, 'Upload failed', error.message);
   }
-}
+};

--- a/api/upload.js
+++ b/api/upload.js
@@ -1,115 +1,47 @@
 const formidable = require('formidable');
-const { 
-  authenticateHybrid, 
-  handleCors, 
-  errorResponse, 
-  successResponse 
-} = require('./utils');
-const { putObject } = require('./r2-client');
+const { authenticateHybrid, handleCors, errorResponse, successResponse, setCookie } = require('./utils');
+const { resolveClientAndBucket, putObject } = require('./r2-client');
 
 module.exports = async function handler(req, res) {
   if (handleCors(req, res)) return;
-
-  if (req.method !== 'POST') {
-    return errorResponse(res, 405, 'Method not allowed');
-  }
+  if (req.method !== 'POST') return errorResponse(res, 405, 'Method not allowed');
 
   try {
-    // Authenticate using hybrid authentication (supports both API key and JWT session)
-    const { user, newAccessToken } = authenticateHybrid(req);
-    
-    // Set new access token if JWT was refreshed
-    if (newAccessToken) {
-      const { setCookie } = require('./utils');
-      const accessCookie = setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 });
-      res.setHeader('Set-Cookie', accessCookie);
-    }
-    
-    // Parse form data
-    const form = new formidable.IncomingForm({
-      maxFileSize: 4 * 1024 * 1024, // 4MB for Vercel Hobby compatibility
-      maxFiles: 1
-    });
-    
-    const [fields, files] = await form.parse(req);
-    
-    if (!files.file || files.file.length === 0) {
-      return errorResponse(res, 400, 'No file uploaded', 'Please provide a file in the "file" field');
-    }
-    
+    const { newAccessToken } = authenticateHybrid(req);
+    if (newAccessToken) res.setHeader('Set-Cookie', setCookie('accessToken', newAccessToken, { maxAge: 15 * 60 }));
+
+    const { client, bucketName, publicUrl: baseUrl } = await resolveClientAndBucket(req);
+
+    const form = new formidable.IncomingForm({ maxFileSize: 4 * 1024 * 1024, maxFiles: 1 });
+    const [, files] = await form.parse(req);
+    if (!files.file?.length) return errorResponse(res, 400, 'No file uploaded');
     const file = Array.isArray(files.file) ? files.file[0] : files.file;
-    
-    // Validate file
-    if (!file.size || file.size === 0) {
-      return errorResponse(res, 400, 'Empty file uploaded');
-    }
-    
-    // Generate filename with timestamp to avoid conflicts
-    const timestamp = Date.now();
-    const originalName = file.originalFilename || file.name || 'unknown';
-    const filename = `${timestamp}-${originalName}`;
-    
-    // Read file buffer
+    if (!file.size) return errorResponse(res, 400, 'Empty file uploaded');
+
     const fs = require('fs');
+    const timestamp = Date.now();
+    const originalName = file.originalFilename || 'unknown';
     let fileBuffer = fs.readFileSync(file.filepath);
-    
-    // Check if file is an image and not already WebP
-    // We only convert jpg, jpeg, png, tiff, etc. to webp
     let contentType = file.mimetype || 'application/octet-stream';
-    let fileKey = filename;
-    
-    if (contentType.startsWith('image/') && !contentType.includes('webp') && !contentType.includes('svg') && !contentType.includes('gif')) {
+    let fileKey = `${timestamp}-${originalName}`;
+
+    if (contentType.startsWith('image/') && !['webp','svg','gif'].some(t => contentType.includes(t))) {
       try {
         const sharp = require('sharp');
-        const convertedBuffer = await sharp(fileBuffer)
-          .webp({ quality: 80 }) // Default quality 80
-          .toBuffer();
-          
-        fileBuffer = convertedBuffer;
+        fileBuffer = await sharp(fileBuffer).webp({ quality: 80 }).toBuffer();
         contentType = 'image/webp';
-        
-        // Update filename extension to .webp
-        const nameParts = originalName.split('.');
-        const nameWithoutExt = nameParts.length > 1 ? nameParts.slice(0, -1).join('.') : originalName;
-        const newOriginalName = `${nameWithoutExt}.webp`;
-        fileKey = `${timestamp}-${newOriginalName}`;
-        
-        console.log(`Converted ${originalName} to ${newOriginalName}`);
-      } catch (conversionError) {
-        console.error('Image conversion failed, uploading original:', conversionError);
-        // Fallback to original file if conversion fails
-      }
+        const base = originalName.split('.').slice(0, -1).join('.') || originalName;
+        fileKey = `${timestamp}-${base}.webp`;
+      } catch (e) { console.error('Conversion failed, uploading original:', e); }
     }
-    
-    // Upload to R2
-    await putObject({
-      Bucket: process.env.R2_BUCKET_NAME,
-      Key: fileKey,
-      Body: fileBuffer,
-      ContentType: contentType,
-    });
-    
-    // Build file URLs
-    const baseUrl = process.env.R2_PUBLIC_URL || '';
+
+    await putObject(client, { Bucket: bucketName, Key: fileKey, Body: fileBuffer, ContentType: contentType });
     const publicUrl = baseUrl ? `${baseUrl.replace(/\/$/, '')}/${fileKey}` : null;
-    const downloadUrl = `/r2/download/${fileKey}`;
-    
-    return successResponse(res, {
-      filename: fileKey,
-      originalName: originalName,
-      key: fileKey,
-      size: fileBuffer.length, // Use actual buffer length after conversion
-      contentType: contentType,
-      publicUrl: publicUrl,
-      downloadUrl: downloadUrl,
-      uploadedAt: new Date().toISOString()
-    }, 'File uploaded successfully');
-    
+
+    return successResponse(res, { filename: fileKey, originalName, key: fileKey, size: fileBuffer.length, contentType, publicUrl, downloadUrl: `/r2/download/${fileKey}`, uploadedAt: new Date().toISOString() }, 'File uploaded successfully');
   } catch (error) {
     console.error('API Upload error:', error);
-    if (error.message.includes('API key') || error.message.includes('token') || error.message.includes('authenticate')) {
-      return errorResponse(res, 401, error.message);
-    }
+    if (error.message.includes('API key') || error.message.includes('token') || error.message.includes('authenticate')) return errorResponse(res, 401, error.message);
     return errorResponse(res, 500, 'Upload failed', error.message);
   }
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.1",
         "sharp": "^0.33.5",
-        "uuid": "^14.0.0"
+        "uuid": "^9.0.1"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"
@@ -3691,16 +3691,16 @@
       }
     },
     "node_modules/uuid": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
-      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
       "bin": {
-        "uuid": "dist-node/bin/uuid"
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,13 +18,14 @@
         "formidable": "^3.5.4",
         "jsonwebtoken": "^9.0.2",
         "multer": "^2.0.1",
-        "sharp": "^0.33.5"
+        "sharp": "^0.33.5",
+        "uuid": "^14.0.0"
       },
       "devDependencies": {
         "nodemon": "^3.0.1"
       },
       "engines": {
-        "node": "22.x"
+        "node": ">=22.x"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -3687,6 +3688,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
       }
     },
     "node_modules/vary": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,12 @@
 {
   "name": "file-service",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "file-service",
+      "version": "1.0.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.837.0",
         "@aws-sdk/s3-request-presigner": "^3.837.0",
@@ -12,9 +14,17 @@
         "cookie-parser": "^1.4.7",
         "cors": "^2.8.5",
         "dotenv": "^16.5.0",
-        "express": "^5.1.0",
+        "express": "^4.19.2",
+        "formidable": "^3.5.4",
         "jsonwebtoken": "^9.0.2",
-        "multer": "^2.0.1"
+        "multer": "^2.0.1",
+        "sharp": "^0.33.5"
+      },
+      "devDependencies": {
+        "nodemon": "^3.0.1"
+      },
+      "engines": {
+        "node": "22.x"
       }
     },
     "node_modules/@aws-crypto/crc32": {
@@ -220,631 +230,616 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.837.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.837.0.tgz",
-      "integrity": "sha512-sBjPPG30HIfNwpzWuajCDf7agb4YAxPFFpsp3kwgptJF8PEi0HzQg64bskquMzjqLC2tXsn5rKtDVpQOvs29MQ==",
+      "version": "3.1036.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1036.0.tgz",
+      "integrity": "sha512-QGjLHw1xklwWX+MWt/7X66lMxjNQLOb0tjcwAU3PaBrYZ51kphDlfvc2sInNEsIU03+I158Y4WSMhl8l71SAsw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/credential-provider-node": "3.835.0",
-        "@aws-sdk/middleware-bucket-endpoint": "3.830.0",
-        "@aws-sdk/middleware-expect-continue": "3.821.0",
-        "@aws-sdk/middleware-flexible-checksums": "3.835.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-location-constraint": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-sdk-s3": "3.835.0",
-        "@aws-sdk/middleware-ssec": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.835.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/signature-v4-multi-region": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.835.0",
-        "@aws-sdk/xml-builder": "3.821.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/eventstream-serde-browser": "^4.0.4",
-        "@smithy/eventstream-serde-config-resolver": "^4.1.2",
-        "@smithy/eventstream-serde-node": "^4.0.4",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-blob-browser": "^4.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/hash-stream-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/md5-js": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.12",
-        "@smithy/middleware-retry": "^4.1.13",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.20",
-        "@smithy/util-defaults-mode-node": "^4.0.20",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.6",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
-        "@smithy/util-waiter": "^4.0.5",
-        "@types/uuid": "^9.0.1",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
-      },
-      "engines": {
-        "node": ">=18.0.0"
-      }
-    },
-    "node_modules/@aws-sdk/client-sso": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.835.0.tgz",
-      "integrity": "sha512-4J19IcBKU5vL8yw/YWEvbwEGcmCli0rpRyxG53v0K5/3weVPxVBbKfkWcjWVQ4qdxNz2uInfbTde4BRBFxWllQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@aws-crypto/sha256-browser": "5.2.0",
-        "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.835.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.835.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.12",
-        "@smithy/middleware-retry": "^4.1.13",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.20",
-        "@smithy/util-defaults-mode-node": "^4.0.20",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.6",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-node": "^3.972.36",
+        "@aws-sdk/middleware-bucket-endpoint": "^3.972.10",
+        "@aws-sdk/middleware-expect-continue": "^3.972.10",
+        "@aws-sdk/middleware-flexible-checksums": "^3.974.13",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-location-constraint": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
+        "@aws-sdk/middleware-ssec": "^3.972.10",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/eventstream-serde-browser": "^4.2.14",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.14",
+        "@smithy/eventstream-serde-node": "^4.2.14",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-blob-browser": "^4.2.15",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/hash-stream-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/md5-js": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/util-waiter": "^4.2.16",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.835.0.tgz",
-      "integrity": "sha512-7mnf4xbaLI8rkDa+w6fUU48dG6yDuOgLXEPe4Ut3SbMp1ceJBPMozNHbCwkiyHk3HpxZYf8eVy0wXhJMrxZq5w==",
+      "version": "3.974.5",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
+      "integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/xml-builder": "3.821.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-utf8": "^4.0.0",
-        "fast-xml-parser": "4.4.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/xml-builder": "^3.972.19",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/crc64-nvme": {
+      "version": "3.972.7",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
+      "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.835.0.tgz",
-      "integrity": "sha512-U9LFWe7+ephNyekpUbzT7o6SmJTmn6xkrPkE0D7pbLojnPVi/8SZKyjtgQGIsAv+2kFkOCqMOIYUKd/0pE7uew==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.31.tgz",
+      "integrity": "sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.835.0.tgz",
-      "integrity": "sha512-jCdNEsQklil7frDm/BuVKl4ubVoQHRbV6fnkOjmxAJz0/v7cR8JP0jBGlqKKzh3ROh5/vo1/5VUZbCTLpc9dSg==",
+      "version": "3.972.33",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.33.tgz",
+      "integrity": "sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.835.0.tgz",
-      "integrity": "sha512-nqF6rYRAnJedmvDfrfKygzyeADcduDvtvn7GlbQQbXKeR2l7KnCdhuxHa0FALLvspkHiBx7NtInmvnd5IMuWsw==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.35.tgz",
+      "integrity": "sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/credential-provider-env": "3.835.0",
-        "@aws-sdk/credential-provider-http": "3.835.0",
-        "@aws-sdk/credential-provider-process": "3.835.0",
-        "@aws-sdk/credential-provider-sso": "3.835.0",
-        "@aws-sdk/credential-provider-web-identity": "3.835.0",
-        "@aws-sdk/nested-clients": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-login": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.35.tgz",
+      "integrity": "sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.835.0.tgz",
-      "integrity": "sha512-77B8elyZlaEd7vDYyCnYtVLuagIBwuJ0AQ98/36JMGrYX7TT8UVAhiDAfVe0NdUOMORvDNFfzL06VBm7wittYw==",
+      "version": "3.972.36",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.36.tgz",
+      "integrity": "sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "3.835.0",
-        "@aws-sdk/credential-provider-http": "3.835.0",
-        "@aws-sdk/credential-provider-ini": "3.835.0",
-        "@aws-sdk/credential-provider-process": "3.835.0",
-        "@aws-sdk/credential-provider-sso": "3.835.0",
-        "@aws-sdk/credential-provider-web-identity": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/credential-provider-env": "^3.972.31",
+        "@aws-sdk/credential-provider-http": "^3.972.33",
+        "@aws-sdk/credential-provider-ini": "^3.972.35",
+        "@aws-sdk/credential-provider-process": "^3.972.31",
+        "@aws-sdk/credential-provider-sso": "^3.972.35",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.835.0.tgz",
-      "integrity": "sha512-qXkTt5pAhSi2Mp9GdgceZZFo/cFYrA735efqi/Re/nf0lpqBp8mRM8xv+iAaPHV4Q10q0DlkbEidT1DhxdT/+w==",
+      "version": "3.972.31",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.31.tgz",
+      "integrity": "sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.835.0.tgz",
-      "integrity": "sha512-jAiEMryaPFXayYGszrc7NcgZA/zrrE3QvvvUBh/Udasg+9Qp5ZELdJCm/p98twNyY9n5i6Ex6VgvdxZ7+iEheQ==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.35.tgz",
+      "integrity": "sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-sso": "3.835.0",
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/token-providers": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/token-providers": "3.1036.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.835.0.tgz",
-      "integrity": "sha512-zfleEFXDLlcJ7cyfS4xSyCRpd8SVlYZfH3rp0pg2vPYKbnmXVE0r+gPIYXl4L+Yz4A2tizYl63nKCNdtbxadog==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.35.tgz",
+      "integrity": "sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/nested-clients": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.830.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.830.0.tgz",
-      "integrity": "sha512-ElVeCReZSH5Ds+/pkL5ebneJjuo8f49e9JXV1cYizuH0OAOQfYaBU9+M+7+rn61pTttOFE8W//qKzrXBBJhfMg==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.10.tgz",
+      "integrity": "sha512-Vbc2frZH7wXlMNd+ZZSXUEs/l1Sv8Jj4zUnIfwrYF5lwaLdXHZ9xx4U3rjUcaye3HRhFVc+E5DbBxpRAbB16BA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-arn-parser": "3.804.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.821.0.tgz",
-      "integrity": "sha512-zAOoSZKe1njOrtynvK6ZORU57YGv5I7KP4+rwOvUN3ZhJbQ7QPf8gKtFUCYAPRMegaXCKF/ADPtDZBAmM+zZ9g==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.10.tgz",
+      "integrity": "sha512-2Yn0f1Qiq/DjxYR3wfI3LokXnjOhFM7Ssn4LTdFDIxRMCE6I32MAsVnhPX1cUZsuVA9tiZtwwhlSLAtFGxAZlQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.835.0.tgz",
-      "integrity": "sha512-9ezorQYlr5cQY28zWAReFhNKUTaXsi3TMvXIagMRrSeWtQ7R6TCYnt91xzHRCmFR2kp3zLI+dfoeH+wF3iCKUw==",
+      "version": "3.974.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.13.tgz",
+      "integrity": "sha512-b6QUe2hQX9XsnCzp6mtzVaERhganDKeb8lmGL6pVhr7rRVH9S9keDFW7uKytuuqmcY5943FixoGqn/QL+sbUBA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
         "@aws-crypto/crc32c": "5.2.0",
         "@aws-crypto/util": "5.2.0",
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/crc64-nvme": "^3.972.7",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.821.0.tgz",
-      "integrity": "sha512-xSMR+sopSeWGx5/4pAGhhfMvGBHioVBbqGvDs6pG64xfNwM5vq5s5v6D04e2i+uSTj4qGa71dLUs5I0UzAK3sw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+      "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.821.0.tgz",
-      "integrity": "sha512-sKrm80k0t3R0on8aA/WhWFoMaAl4yvdk+riotmMElLUpcMcRXAd1+600uFVrxJqZdbrKQ0mjX0PjT68DlkYXLg==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.10.tgz",
+      "integrity": "sha512-rI3NZvJcEvjoD0+0PI0iUAwlPw2IlSlhyvgBK/3WkKJQE/YiKFedd9dMN2lVacdNxPNhxL/jzQaKQdrGtQagjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.821.0.tgz",
-      "integrity": "sha512-0cvI0ipf2tGx7fXYEEN5fBeZDz2RnHyb9xftSgUsEq7NBxjV0yTZfLJw6Za5rjE6snC80dRN8+bTNR1tuG89zA==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+      "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.821.0.tgz",
-      "integrity": "sha512-efmaifbhBoqKG3bAoEfDdcM8hn1psF+4qa7ykWuYmfmah59JBeqHLfz5W9m9JoTwoKPkFcVLWZxnyZzAnVBOIg==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+      "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.835.0.tgz",
-      "integrity": "sha512-oPebxpVf9smInHhevHh3APFZagGU+4RPwXEWv9YtYapFvsMq+8QXFvOfxfVZ/mwpe0JVG7EiJzL9/9Kobmts8Q==",
+      "version": "3.972.34",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
+      "integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-arn-parser": "3.804.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/signature-v4": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-arn-parser": "^3.972.3",
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.821.0.tgz",
-      "integrity": "sha512-YYi1Hhr2AYiU/24cQc8HIB+SWbQo6FBkMYojVuz/zgrtkFmALxENGF/21OPg7f/QWd+eadZJRxCjmRwh5F2Cxg==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.10.tgz",
+      "integrity": "sha512-Gli9A0u8EVVb+5bFDGS/QbSVg28w/wpEidg1ggVcSj65BDTdGR6punsOcVjqdiu1i42WHWo51MCvARPIIz9juw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.835.0.tgz",
-      "integrity": "sha512-2gmAYygeE/gzhyF2XlkcbMLYFTbNfV61n+iCFa/ZofJHXYE+RxSyl5g4kujLEs7bVZHmjQZJXhprVSkGccq3/w==",
+      "version": "3.972.35",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.35.tgz",
+      "integrity": "sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@smithy/core": "^3.5.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-retry": "^4.3.4",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.835.0.tgz",
-      "integrity": "sha512-UtmOO0U5QkicjCEv+B32qqRAnS7o2ZkZhC+i3ccH1h3fsfaBshpuuNBwOYAzRCRBeKW5fw3ANFrV/+2FTp4jWg==",
+      "version": "3.997.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.3.tgz",
+      "integrity": "sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
         "@aws-crypto/sha256-js": "5.2.0",
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/middleware-host-header": "3.821.0",
-        "@aws-sdk/middleware-logger": "3.821.0",
-        "@aws-sdk/middleware-recursion-detection": "3.821.0",
-        "@aws-sdk/middleware-user-agent": "3.835.0",
-        "@aws-sdk/region-config-resolver": "3.821.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-endpoints": "3.828.0",
-        "@aws-sdk/util-user-agent-browser": "3.821.0",
-        "@aws-sdk/util-user-agent-node": "3.835.0",
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/core": "^3.5.3",
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/hash-node": "^4.0.4",
-        "@smithy/invalid-dependency": "^4.0.4",
-        "@smithy/middleware-content-length": "^4.0.4",
-        "@smithy/middleware-endpoint": "^4.1.12",
-        "@smithy/middleware-retry": "^4.1.13",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-body-length-node": "^4.0.0",
-        "@smithy/util-defaults-mode-browser": "^4.0.20",
-        "@smithy/util-defaults-mode-node": "^4.0.20",
-        "@smithy/util-endpoints": "^3.0.6",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.6",
-        "@smithy/util-utf8": "^4.0.0",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/middleware-host-header": "^3.972.10",
+        "@aws-sdk/middleware-logger": "^3.972.10",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/region-config-resolver": "^3.972.13",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-endpoints": "^3.996.8",
+        "@aws-sdk/util-user-agent-browser": "^3.972.10",
+        "@aws-sdk/util-user-agent-node": "^3.973.21",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/core": "^3.23.17",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/hash-node": "^4.2.14",
+        "@smithy/invalid-dependency": "^4.2.14",
+        "@smithy/middleware-content-length": "^4.2.14",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-retry": "^4.5.5",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-body-length-node": "^4.2.3",
+        "@smithy/util-defaults-mode-browser": "^4.3.49",
+        "@smithy/util-defaults-mode-node": "^4.2.54",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.821.0.tgz",
-      "integrity": "sha512-t8og+lRCIIy5nlId0bScNpCkif8sc0LhmtaKsbm0ZPm3sCa/WhCbSZibjbZ28FNjVCV+p0D9RYZx0VDDbtWyjw==",
+      "version": "3.972.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+      "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.837.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.837.0.tgz",
-      "integrity": "sha512-h/D/cqeciBPGFSHIHRQm0q/CDvToV4rUoPef3tWzYtfoKzqfYaqRO175FnDv/4XgOYpdoqv6q36bx8KueVQ62w==",
+      "version": "3.1036.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.1036.0.tgz",
+      "integrity": "sha512-5LEXxcZrrCrPvd7/zIyadEIBsMeXyT6sg9tn3OkkwZ9Rl6Wfq7gxOI82Ei30cj0QXvzJwjcizpskmPh8M5QNtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@aws-sdk/util-format-url": "3.821.0",
-        "@smithy/middleware-endpoint": "^4.1.12",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/smithy-client": "^4.4.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+        "@aws-sdk/types": "^3.973.8",
+        "@aws-sdk/util-format-url": "^3.972.10",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.835.0.tgz",
-      "integrity": "sha512-rEtJH4dIwJYlXXe5rIH+uTCQmd2VIjuaoHlDY3Dr4nxF6po6U7vKsLfybIU2tgflGVqoqYQnXsfW/kj/Rh+/ow==",
+      "version": "3.996.22",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
+      "integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/signature-v4": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.34",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/signature-v4": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.835.0.tgz",
-      "integrity": "sha512-zN1P3BE+Rv7w7q/CDA8VCQox6SE9QTn0vDtQ47AHA3eXZQQgYzBqgoLgJxR9rKKBIRGZqInJa/VRskLL95VliQ==",
+      "version": "3.1036.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1036.0.tgz",
+      "integrity": "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "3.835.0",
-        "@aws-sdk/nested-clients": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/core": "^3.974.5",
+        "@aws-sdk/nested-clients": "^3.997.3",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.821.0.tgz",
-      "integrity": "sha512-Znroqdai1a90TlxGaJ+FK1lwC0fHpo97Xjsp5UKGR5JODYm7f9+/fF17ebO1KdoBr/Rm0UIFiF5VmI8ts9F1eA==",
+      "version": "3.973.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+      "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-arn-parser": {
-      "version": "3.804.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.804.0.tgz",
-      "integrity": "sha512-wmBJqn1DRXnZu3b4EkE6CWnoWMo1ZMvlfkqU5zPz67xx1GMaXlDCchFvKAXMjk4jn/L1O3tKnoFDNsoLV1kgNQ==",
+      "version": "3.972.3",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+      "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.828.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.828.0.tgz",
-      "integrity": "sha512-RvKch111SblqdkPzg3oCIdlGxlQs+k+P7Etory9FmxPHyPDvsP1j1c74PmgYqtzzMWmoXTjd+c9naUHh9xG8xg==",
+      "version": "3.996.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+      "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-endpoints": "^3.0.6",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-endpoints": "^3.4.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-format-url": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.821.0.tgz",
-      "integrity": "sha512-h+xqmPToxDrZ0a7rxE1a8Oh4zpWfZe9oiQUphGtfiGFA6j75UiURH5J3MmGHa/G4t15I3iLLbYtUXxvb1i7evg==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.972.10.tgz",
+      "integrity": "sha512-DEKiHNJVtNxdyTeQspzY+15Po/kHm6sF0Cs4HV9Q2+lplB63+DrvdeiSoOSdWEWAoO2RcY1veoXVDz2tWxWCgQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
@@ -860,31 +855,32 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.821.0.tgz",
-      "integrity": "sha512-irWZHyM0Jr1xhC+38OuZ7JB6OXMLPZlj48thElpsO1ZSLRkLZx5+I7VV6k3sp2yZ7BYbKz/G2ojSv4wdm7XTLw==",
+      "version": "3.972.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+      "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/types": "^4.14.1",
         "bowser": "^2.11.0",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.835.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.835.0.tgz",
-      "integrity": "sha512-gY63QZ4W5w9JYHYuqvUxiVGpn7IbCt1ODPQB0ZZwGGr3WRmK+yyZxCtFjbYhEQDQLgTWpf8YgVxgQLv2ps0PJg==",
+      "version": "3.973.21",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.21.tgz",
+      "integrity": "sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-user-agent": "3.835.0",
-        "@aws-sdk/types": "3.821.0",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
+        "@aws-sdk/middleware-user-agent": "^3.972.35",
+        "@aws-sdk/types": "^3.973.8",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=20.0.0"
       },
       "peerDependencies": {
         "aws-crt": ">=1.0.0"
@@ -896,35 +892,436 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.821.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.821.0.tgz",
-      "integrity": "sha512-DIIotRnefVL6DiaHtO6/21DhJ4JZnnIwdNbpwiAhdt/AVbttcE4yw925gsjur0OGv5BTYXQXU3YnANBYnZjuQA==",
+      "version": "3.972.19",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+      "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
+        "fast-xml-parser": "5.7.1",
         "tslib": "^2.6.2"
       },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.4.tgz",
+      "integrity": "sha512-iY8yvjE0y651BixKNPgmv1WrQc+GZ142sb0z4gYnChDDY2YqI4P/jsSopBWrKfAt7LOJAkOXt7rC/hms+WclQQ==",
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@smithy/abort-controller": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.4.tgz",
-      "integrity": "sha512-gJnEjZMvigPDQWHrW3oPrFhQtkrgqBkyjj3pCIdF3A5M6vsZODG93KNlfJprv6bp4245bdT32fsHK4kkH3KYDA==",
-      "license": "Apache-2.0",
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "tslib": "^2.6.2"
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@img/sharp-darwin-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
+      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-darwin-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
+      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-darwin-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
+      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-darwin-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
+      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
+      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
+      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-s390x": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
+      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
+      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
+      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linuxmusl-x64": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
+      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
+      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm": "1.0.5"
+      }
+    },
+    "node_modules/@img/sharp-linux-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
+      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-s390x": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
+      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-s390x": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
+      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-arm64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
+      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-linuxmusl-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
+      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+      }
+    },
+    "node_modules/@img/sharp-wasm32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
+      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/runtime": "^1.2.0"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-ia32": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
+      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-x64": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
+      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@smithy/chunked-blob-reader": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.0.0.tgz",
-      "integrity": "sha512-+sKqDBQqb036hh4NPaUiEkYFkTUGYzRsn3EuFhyfQfMy6oGHEUJDurLP9Ufb5dasr/XiAmPNMr6wa9afjQB+Gw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.2.tgz",
+      "integrity": "sha512-St+kVicSyayWQca+I1rGitaOEH6uKgE8IUWoYnnEX26SWdWQcL6LvMSD19Lg+vYHKdT9B2Zuu7rd3i6Wnyb/iw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -934,12 +1331,12 @@
       }
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.0.0.tgz",
-      "integrity": "sha512-R9wM2yPmfEMsUmlMlIgSzOyICs0x9uu7UTHoccMyt7BWw8shcGM8HqB355+BZCPBcySvbTYMs62EgEQkNxz2ig==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.3.tgz",
+      "integrity": "sha512-jA5k5Udn7Y5717L86h4EIv06wIr3xn8GM1qHRi/Nf31annXcXHJjBKvgztnbn2TxH3xWrPBfgwHsOwZf0UmQWw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-base64": "^4.0.0",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -947,15 +1344,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.4.tgz",
-      "integrity": "sha512-prmU+rDddxHOH0oNcwemL+SwnzcG65sBF2yXRO7aeXIn/xTlq2pX7JLVbkBnVLowHLg4/OL4+jBmv9hVrVGS+w==",
+      "version": "4.4.17",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+      "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-config-provider": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-config-provider": "^4.2.2",
+        "@smithy/util-endpoints": "^3.4.2",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -963,19 +1361,20 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.6.0.tgz",
-      "integrity": "sha512-Pgvfb+TQ4wUNLyHzvgCP4aYZMh16y7GcfF59oirRHcgGgkH1e/s9C0nv/v3WP+Quymyr5je71HeFQCwh+44XLg==",
+      "version": "3.23.17",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+      "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-body-length-browser": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-stream": "^4.2.2",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-body-length-browser": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-stream": "^4.5.25",
+        "@smithy/util-utf8": "^4.2.2",
+        "@smithy/uuid": "^1.1.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -983,15 +1382,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.6.tgz",
-      "integrity": "sha512-hKMWcANhUiNbCJouYkZ9V3+/Qf9pteR1dnwgdyzR09R4ODEYx8BbUysHwRSyex4rZ9zapddZhLFTnT4ZijR4pw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+      "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -999,14 +1398,14 @@
       }
     },
     "node_modules/@smithy/eventstream-codec": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.0.4.tgz",
-      "integrity": "sha512-7XoWfZqWb/QoR/rAU4VSi0mWnO2vu9/ltS6JZ5ZSZv0eovLVfDfu0/AX4ub33RsJTOth3TiFWSHS5YdztvFnig==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.14.tgz",
+      "integrity": "sha512-erZq0nOIpzfeZdCyzZjdJb4nVSKLUmSkaQUVkRGQTXs30gyUGeKnrYEg+Xe1W5gE3aReS7IgsvANwVPxSzY6Pw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/crc32": "5.2.0",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-hex-encoding": "^4.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1014,13 +1413,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.0.4.tgz",
-      "integrity": "sha512-3fb/9SYaYqbpy/z/H3yIi0bYKyAa89y6xPmIqwr2vQiUT2St+avRt8UKwsWt9fEdEasc5d/V+QjrviRaX1JRFA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.14.tgz",
+      "integrity": "sha512-8IelTCtTctWRbb+0Dcy+C0aICh1qa0qWXqgjcXDmMuCvPJRnv26hiDZoAau2ILOniki65mCPKqOQs/BaWvO4CQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1028,12 +1427,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.1.2.tgz",
-      "integrity": "sha512-JGtambizrWP50xHgbzZI04IWU7LdI0nh/wGbqH3sJesYToMi2j/DcoElqyOcqEIG/D4tNyxgRuaqBXWE3zOFhQ==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.14.tgz",
+      "integrity": "sha512-sqHiHpYRYo3FJlaIxD1J8PhbcmJAm7IuM16mVnwSkCToD7g00IBZzKuiLNMGmftULmEUX6/UAz8/NN5uMP8bVA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1041,13 +1440,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.0.4.tgz",
-      "integrity": "sha512-RD6UwNZ5zISpOWPuhVgRz60GkSIp0dy1fuZmj4RYmqLVRtejFqQ16WmfYDdoSoAjlp1LX+FnZo+/hkdmyyGZ1w==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.14.tgz",
+      "integrity": "sha512-Ht/8BuGlKfFTy0H3+8eEu0vdpwGztCnaLLXtpXNdQqiR7Hj4vFScU3T436vRAjATglOIPjJXronY+1WxxNLSiw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-serde-universal": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/eventstream-serde-universal": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1055,13 +1454,13 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-universal": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.0.4.tgz",
-      "integrity": "sha512-UeJpOmLGhq1SLox79QWw/0n2PFX+oPRE1ZyRMxPIaFEfCqWaqpB7BU9C8kpPOGEhLF7AwEqfFbtwNxGy4ReENA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.14.tgz",
+      "integrity": "sha512-lWyt4T2XQZUZgK3tQ3Wn0w3XBvZsK/vjTuJl6bXbnGZBHH0ZUSONTYiK9TgjTTzU54xQr3DRFwpjmhp0oLm3gg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/eventstream-codec": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/eventstream-codec": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1069,15 +1468,15 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.4.tgz",
-      "integrity": "sha512-AMtBR5pHppYMVD7z7G+OlHHAcgAN7v0kVKEpHuTO4Gb199Gowh0taYi9oDStFeUhetkeP55JLSVlTW1n9rFtUw==",
+      "version": "5.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+      "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1085,14 +1484,14 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.0.4.tgz",
-      "integrity": "sha512-WszRiACJiQV3QG6XMV44i5YWlkrlsM5Yxgz4jvsksuu7LDXA6wAtypfPajtNTadzpJy3KyJPoWehYpmZGKUFIQ==",
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.15.tgz",
+      "integrity": "sha512-0PJ4Al3fg2nM4qKrAIxyNcApgqHAXcBkN8FeizOz69z0rb26uZ6lMESYtxegaTlXB5Hj84JfwMPavMrwDMjucA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/chunked-blob-reader": "^5.0.0",
-        "@smithy/chunked-blob-reader-native": "^4.0.0",
-        "@smithy/types": "^4.3.1",
+        "@smithy/chunked-blob-reader": "^5.2.2",
+        "@smithy/chunked-blob-reader-native": "^4.2.3",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1100,14 +1499,14 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.4.tgz",
-      "integrity": "sha512-qnbTPUhCVnCgBp4z4BUJUhOEkVwxiEi1cyFM+Zj6o+aY8OFGxUQleKWq8ltgp3dujuhXojIvJWdoqpm6dVO3lQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+      "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1115,13 +1514,13 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.0.4.tgz",
-      "integrity": "sha512-wHo0d8GXyVmpmMh/qOR0R7Y46/G1y6OR8U+bSTB4ppEzRxd1xVAQ9xOE9hOc0bSjhz0ujCPAbfNLkLrpa6cevg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.14.tgz",
+      "integrity": "sha512-tw4GANWkZPb6+BdD4Fgucqzey2+r73Z/GRo9zklsCdwrnxxumUV83ZIaBDdudV4Ylazw3EPTiJZhpX42105ruQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1129,12 +1528,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.4.tgz",
-      "integrity": "sha512-bNYMi7WKTJHu0gn26wg8OscncTt1t2b8KcsZxvOv56XA6cyXtOAAAaNP7+m45xfppXfOatXF3Sb1MNsLUgVLTw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+      "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1142,9 +1541,9 @@
       }
     },
     "node_modules/@smithy/is-array-buffer": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
-      "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+      "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1154,13 +1553,13 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.0.4.tgz",
-      "integrity": "sha512-uGLBVqcOwrLvGh/v/jw423yWHq/ofUGK1W31M2TNspLQbUV1Va0F5kTxtirkoHawODAZcjXTSGi7JwbnPcDPJg==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.14.tgz",
+      "integrity": "sha512-V2v0vx+h0iUSNG1Alt+GNBMSLGCrl9iVsdd+Ap67HPM9PN479x12V8LkuMoKImNZxn3MXeuyUjls+/7ZACZghA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1168,13 +1567,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.4.tgz",
-      "integrity": "sha512-F7gDyfI2BB1Kc+4M6rpuOLne5LOcEknH1n6UQB69qv+HucXBR1rkzXBnQTB2q46sFy1PM/zuSJOB532yc8bg3w==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+      "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1182,18 +1581,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.1.13",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.13.tgz",
-      "integrity": "sha512-xg3EHV/Q5ZdAO5b0UiIMj3RIOCobuS40pBBODguUDVdko6YK6QIzCVRrHTogVuEKglBWqWenRnZ71iZnLL3ZAQ==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+      "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.6.0",
-        "@smithy/middleware-serde": "^4.0.8",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
-        "@smithy/url-parser": "^4.0.4",
-        "@smithy/util-middleware": "^4.0.4",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-serde": "^4.2.20",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
+        "@smithy/url-parser": "^4.2.14",
+        "@smithy/util-middleware": "^4.2.14",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1201,33 +1600,35 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.1.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.14.tgz",
-      "integrity": "sha512-eoXaLlDGpKvdmvt+YBfRXE7HmIEtFF+DJCbTPwuLunP0YUnrydl+C4tS+vEM0+nyxXrX3PSUFqC+lP1+EHB1Tw==",
+      "version": "4.5.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.5.tgz",
+      "integrity": "sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/service-error-classification": "^4.0.6",
-        "@smithy/smithy-client": "^4.4.5",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-retry": "^4.0.6",
-        "tslib": "^2.6.2",
-        "uuid": "^9.0.1"
+        "@smithy/core": "^3.23.17",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-retry": "^4.3.4",
+        "@smithy/uuid": "^1.1.2",
+        "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.8.tgz",
-      "integrity": "sha512-iSSl7HJoJaGyMIoNn2B7czghOVwJ9nD7TMvLhMWeSB5vt0TnEYyRRqPJu/TqW76WScaNvYYB8nRoiBHR9S1Ddw==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+      "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
+        "@smithy/core": "^3.23.17",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1235,12 +1636,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.4.tgz",
-      "integrity": "sha512-kagK5ggDrBUCCzI93ft6DjteNSfY8Ulr83UtySog/h09lTIOAJ/xUSObutanlPT0nhoHAkpmW9V5K8oPyLh+QA==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+      "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1248,14 +1649,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.1.3.tgz",
-      "integrity": "sha512-HGHQr2s59qaU1lrVH6MbLlmOBxadtzTsoO4c+bF5asdgVik3I8o7JIOzoeqWc5MjVa+vD36/LWE0iXKpNqooRw==",
+      "version": "4.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+      "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/shared-ini-file-loader": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/shared-ini-file-loader": "^4.4.9",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1263,15 +1664,14 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.6.tgz",
-      "integrity": "sha512-NqbmSz7AW2rvw4kXhKGrYTiJVDHnMsFnX4i+/FzcZAfbOBauPYs2ekuECkSbtqaxETLLTu9Rl/ex6+I2BKErPA==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+      "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/querystring-builder": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/querystring-builder": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1279,12 +1679,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.4.tgz",
-      "integrity": "sha512-qHJ2sSgu4FqF4U/5UUp4DhXNmdTrgmoAai6oQiM+c5RZ/sbDwJ12qxB1M6FnP+Tn/ggkPZf9ccn4jqKSINaquw==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+      "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1292,12 +1692,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.2.tgz",
-      "integrity": "sha512-rOG5cNLBXovxIrICSBm95dLqzfvxjEmuZx4KK3hWwPFHGdW3lxY0fZNXfv2zebfRO7sJZ5pKJYHScsqopeIWtQ==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+      "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1305,13 +1705,13 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.4.tgz",
-      "integrity": "sha512-SwREZcDnEYoh9tLNgMbpop+UTGq44Hl9tdj3rf+yeLcfH7+J8OXEBaMc2kDxtyRHu8BhSg9ADEx0gFHvpJgU8w==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+      "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-uri-escape": "^4.0.0",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-uri-escape": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1319,12 +1719,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.4.tgz",
-      "integrity": "sha512-6yZf53i/qB8gRHH/l2ZwUG5xgkPgQF15/KxH0DdXMDHjesA9MeZje/853ifkSY0x4m5S+dfDZ+c4x439PF0M2w==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+      "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1332,24 +1732,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.6.tgz",
-      "integrity": "sha512-RRoTDL//7xi4tn5FrN2NzH17jbgmnKidUqd4KvquT0954/i6CXXkh1884jBiunq24g9cGtPBEXlU40W6EpNOOg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
+      "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1"
+        "@smithy/types": "^4.14.1"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.4.tgz",
-      "integrity": "sha512-63X0260LoFBjrHifPDs+nM9tV0VMkOTl4JRMYNuKh/f5PauSjowTfvF3LogfkWdcPoxsA9UjqEOgjeYIbhb7Nw==",
+      "version": "4.4.9",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+      "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1357,18 +1757,18 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.2.tgz",
-      "integrity": "sha512-d3+U/VpX7a60seHziWnVZOHuEgJlclufjkS6zhXvxcJgkJq4UWdH5eOBLzHRMx6gXjsdT9h6lfpmLzbrdupHgQ==",
+      "version": "5.3.14",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+      "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-middleware": "^4.0.4",
-        "@smithy/util-uri-escape": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.2.2",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-middleware": "^4.2.14",
+        "@smithy/util-uri-escape": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1376,17 +1776,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.4.5.tgz",
-      "integrity": "sha512-+lynZjGuUFJaMdDYSTMnP/uPBBXXukVfrJlP+1U/Dp5SFTEI++w6NMga8DjOENxecOF71V9Z2DllaVDYRnGlkg==",
+      "version": "4.12.13",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+      "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.6.0",
-        "@smithy/middleware-endpoint": "^4.1.13",
-        "@smithy/middleware-stack": "^4.0.4",
-        "@smithy/protocol-http": "^5.1.2",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-stream": "^4.2.2",
+        "@smithy/core": "^3.23.17",
+        "@smithy/middleware-endpoint": "^4.4.32",
+        "@smithy/middleware-stack": "^4.2.14",
+        "@smithy/protocol-http": "^5.3.14",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-stream": "^4.5.25",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1394,9 +1794,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.3.1.tgz",
-      "integrity": "sha512-UqKOQBL2x6+HWl3P+3QqFD4ncKq0I8Nuz9QItGv5WuKuMHuuwlhvqcZCoXGfc+P1QmfJE7VieykoYYmrOoFJxA==",
+      "version": "4.14.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+      "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1406,13 +1806,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.4.tgz",
-      "integrity": "sha512-eMkc144MuN7B0TDA4U2fKs+BqczVbk3W+qIvcoCY6D1JY3hnAdCuhCZODC+GAeaxj0p6Jroz4+XMUn3PCxQQeQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+      "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/querystring-parser": "^4.2.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1420,13 +1820,13 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
-      "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+      "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1434,9 +1834,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
-      "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+      "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1446,9 +1846,9 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
-      "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+      "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1458,12 +1858,12 @@
       }
     },
     "node_modules/@smithy/util-buffer-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
-      "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+      "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/is-array-buffer": "^4.0.0",
+        "@smithy/is-array-buffer": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1471,9 +1871,9 @@
       }
     },
     "node_modules/@smithy/util-config-provider": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
-      "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+      "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1483,15 +1883,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.21.tgz",
-      "integrity": "sha512-wM0jhTytgXu3wzJoIqpbBAG5U6BwiubZ6QKzSbP7/VbmF1v96xlAbX2Am/mz0Zep0NLvLh84JT0tuZnk3wmYQA==",
+      "version": "4.3.49",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+      "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.5",
-        "@smithy/types": "^4.3.1",
-        "bowser": "^2.11.0",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1499,17 +1898,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.0.21",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.21.tgz",
-      "integrity": "sha512-/F34zkoU0GzpUgLJydHY8Rxu9lBn8xQC/s/0M0U9lLBkYbA1htaAFjWYJzpzsbXPuri5D1H8gjp2jBum05qBrA==",
+      "version": "4.2.54",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+      "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.1.4",
-        "@smithy/credential-provider-imds": "^4.0.6",
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/property-provider": "^4.0.4",
-        "@smithy/smithy-client": "^4.4.5",
-        "@smithy/types": "^4.3.1",
+        "@smithy/config-resolver": "^4.4.17",
+        "@smithy/credential-provider-imds": "^4.2.14",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/property-provider": "^4.2.14",
+        "@smithy/smithy-client": "^4.12.13",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1517,13 +1916,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.6.tgz",
-      "integrity": "sha512-YARl3tFL3WgPuLzljRUnrS2ngLiUtkwhQtj8PAL13XZSyUiNLQxwG3fBBq3QXFqGFUXepIN73pINp3y8c2nBmA==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+      "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.1.3",
-        "@smithy/types": "^4.3.1",
+        "@smithy/node-config-provider": "^4.3.14",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1531,9 +1930,9 @@
       }
     },
     "node_modules/@smithy/util-hex-encoding": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
-      "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+      "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1543,12 +1942,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.4.tgz",
-      "integrity": "sha512-9MLKmkBmf4PRb0ONJikCbCwORACcil6gUWojwARCClT7RmLzF04hUR4WdRprIXal7XVyrddadYNfp2eF3nrvtQ==",
+      "version": "4.2.14",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+      "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1556,13 +1955,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.6.tgz",
-      "integrity": "sha512-+YekoF2CaSMv6zKrA6iI/N9yva3Gzn4L6n35Luydweu5MMPYpiGZlWqehPHDHyNbnyaYlz/WJyYAZnC+loBDZg==",
+      "version": "4.3.4",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.4.tgz",
+      "integrity": "sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.0.6",
-        "@smithy/types": "^4.3.1",
+        "@smithy/service-error-classification": "^4.3.0",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1570,18 +1969,18 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.2.tgz",
-      "integrity": "sha512-aI+GLi7MJoVxg24/3J1ipwLoYzgkB4kUfogZfnslcYlynj3xsQ0e7vk4TnTro9hhsS5PvX1mwmkRqqHQjwcU7w==",
+      "version": "4.5.25",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+      "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.0.4",
-        "@smithy/node-http-handler": "^4.0.6",
-        "@smithy/types": "^4.3.1",
-        "@smithy/util-base64": "^4.0.0",
-        "@smithy/util-buffer-from": "^4.0.0",
-        "@smithy/util-hex-encoding": "^4.0.0",
-        "@smithy/util-utf8": "^4.0.0",
+        "@smithy/fetch-http-handler": "^5.3.17",
+        "@smithy/node-http-handler": "^4.6.1",
+        "@smithy/types": "^4.14.1",
+        "@smithy/util-base64": "^4.3.2",
+        "@smithy/util-buffer-from": "^4.2.2",
+        "@smithy/util-hex-encoding": "^4.2.2",
+        "@smithy/util-utf8": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1589,9 +1988,9 @@
       }
     },
     "node_modules/@smithy/util-uri-escape": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
-      "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+      "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1601,12 +2000,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
-      "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+      "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/util-buffer-from": "^4.0.0",
+        "@smithy/util-buffer-from": "^4.2.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1614,36 +2013,55 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.0.6.tgz",
-      "integrity": "sha512-slcr1wdRbX7NFphXZOxtxRNA7hXAAtJAXJDE/wdoMAos27SIquVCKiSqfB6/28YzQ8FCsB5NKkhdM5gMADbqxg==",
+      "version": "4.2.16",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.16.tgz",
+      "integrity": "sha512-GtclrKoZ3Lt7jPQ7aTIYKfjY92OgceScftVnkTsG8e1KV8rkvZgN+ny6YSRhd9hxB8rZtwVbmln7NTvE5O3GmQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.0.4",
-        "@smithy/types": "^4.3.1",
+        "@smithy/types": "^4.14.1",
         "tslib": "^2.6.2"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "license": "MIT"
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+      "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
     },
     "node_modules/accepts": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
-      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
       "license": "MIT",
       "dependencies": {
-        "mime-types": "^3.0.0",
-        "negotiator": "^1.0.0"
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/append-field": {
@@ -1651,6 +2069,28 @@
       "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
       "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==",
       "license": "MIT"
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "license": "MIT"
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/bcryptjs": {
       "version": "3.0.2",
@@ -1661,31 +2101,74 @@
         "bcrypt": "bin/bcrypt"
       }
     },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/body-parser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.2.0.tgz",
-      "integrity": "sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==",
+      "version": "1.20.4",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
+      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "^3.1.2",
-        "content-type": "^1.0.5",
-        "debug": "^4.4.0",
-        "http-errors": "^2.0.0",
-        "iconv-lite": "^0.6.3",
-        "on-finished": "^2.4.1",
-        "qs": "^6.14.0",
-        "raw-body": "^3.0.0",
-        "type-is": "^2.0.0"
+        "bytes": "~3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "~1.2.0",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "on-finished": "~2.4.1",
+        "qs": "~6.14.0",
+        "raw-body": "~2.5.3",
+        "type-is": "~1.6.18",
+        "unpipe": "~1.0.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
       }
     },
     "node_modules/bowser": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-      "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+      "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
       "license": "MIT"
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -1748,6 +2231,72 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/color": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
+      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1",
+        "color-string": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=12.5.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
+    },
+    "node_modules/color-string": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
+      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "^1.0.0",
+        "simple-swizzle": "^0.2.2"
+      }
+    },
     "node_modules/concat-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
@@ -1764,9 +2313,9 @@
       }
     },
     "node_modules/content-disposition": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.0.tgz",
-      "integrity": "sha512-Au9nRL8VNUut/XSzbQA38+M78dzP4D+eqg3gfJHMIHHYa3bg067xj1KxMUWj+VULbiZMowKngFFbKczUrNJ1mg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
       "license": "MIT",
       "dependencies": {
         "safe-buffer": "5.2.1"
@@ -1813,13 +2362,10 @@
       "license": "MIT"
     },
     "node_modules/cookie-signature": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
-      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6.6.0"
-      }
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.7.tgz",
+      "integrity": "sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==",
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -1835,21 +2381,19 @@
       }
     },
     "node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
       "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
+        "ms": "2.0.0"
       }
+    },
+    "node_modules/debug/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
     },
     "node_modules/depd": {
       "version": "2.0.0",
@@ -1858,6 +2402,35 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -1956,84 +2529,133 @@
       }
     },
     "node_modules/express": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/express/-/express-5.1.0.tgz",
-      "integrity": "sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==",
+      "version": "4.22.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
+      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
       "dependencies": {
-        "accepts": "^2.0.0",
-        "body-parser": "^2.2.0",
-        "content-disposition": "^1.0.0",
-        "content-type": "^1.0.5",
-        "cookie": "^0.7.1",
-        "cookie-signature": "^1.2.1",
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "finalhandler": "^2.1.0",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "merge-descriptors": "^2.0.0",
-        "mime-types": "^3.0.0",
-        "on-finished": "^2.4.1",
-        "once": "^1.4.0",
-        "parseurl": "^1.3.3",
-        "proxy-addr": "^2.0.7",
-        "qs": "^6.14.0",
-        "range-parser": "^1.2.1",
-        "router": "^2.2.0",
-        "send": "^1.1.0",
-        "serve-static": "^2.2.0",
-        "statuses": "^2.0.1",
-        "type-is": "^2.0.1",
-        "vary": "^1.1.2"
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "~1.20.3",
+        "content-disposition": "~0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "~0.7.1",
+        "cookie-signature": "~1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "~1.3.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "~0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "~6.14.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "~0.19.0",
+        "serve-static": "~1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "~2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 0.10.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/fast-xml-parser": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.4.1.tgz",
-      "integrity": "sha512-xkjOecfnKGkSsOwtZ5Pz7Us/T6mrbPQrq0nh+aCO5V9nk5NLWmasAHumTKjiPJPWANe+kAZ84Jc8ooJkzZ88Sw==",
+    "node_modules/fast-xml-builder": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+      "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/NaturalIntelligence"
-        },
-        {
-          "type": "paypal",
-          "url": "https://paypal.me/naturalintelligence"
         }
       ],
       "license": "MIT",
       "dependencies": {
-        "strnum": "^1.0.5"
+        "path-expression-matcher": "^1.1.3"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+      "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.1.5",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.2.3"
       },
       "bin": {
         "fxparser": "src/cli/cli.js"
       }
     },
-    "node_modules/finalhandler": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
-      "integrity": "sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==",
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.0",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "on-finished": "^2.4.1",
-        "parseurl": "^1.3.3",
-        "statuses": "^2.0.1"
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
+      "integrity": "sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "~2.0.2",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -2046,12 +2668,27 @@
       }
     },
     "node_modules/fresh": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
-      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.8"
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2100,6 +2737,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -2110,6 +2760,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/has-symbols": {
@@ -2125,9 +2785,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -2137,41 +2797,43 @@
       }
     },
     "node_modules/http-errors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
-      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
       "license": "MIT",
       "dependencies": {
-        "depd": "2.0.0",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": "2.0.1",
-        "toidentifier": "1.0.1"
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/http-errors/node_modules/statuses": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
-      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
     },
     "node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
       "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "safer-buffer": ">= 2.1.2 < 3"
       },
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/inherits": {
       "version": "2.0.4",
@@ -2188,11 +2850,57 @@
         "node": ">= 0.10"
       }
     },
-    "node_modules/is-promise": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
-      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+    "node_modules/is-arrayish": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
+      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
       "license": "MIT"
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
     },
     "node_modules/jsonwebtoken": {
       "version": "9.0.2",
@@ -2228,12 +2936,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },
@@ -2289,93 +2997,6 @@
       }
     },
     "node_modules/media-typer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.0.tgz",
-      "integrity": "sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
-    "node_modules/merge-descriptors": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
-      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/mime-db": {
-      "version": "1.54.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
-      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/mime-types": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.1.tgz",
-      "integrity": "sha512-xRc4oEhT6eaBpU1XF7AjpOFD+xQmXNB5OVKwp4tqCuBpHLS/ZbBDrc07mYTDqVMg6PfxUjjNp85O6Cd2Z/5HWA==",
-      "license": "MIT",
-      "dependencies": {
-        "mime-db": "^1.54.0"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/minimist": {
-      "version": "1.2.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
-      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/mkdirp": {
-      "version": "0.5.6",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
-      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
-      "license": "MIT",
-      "dependencies": {
-        "minimist": "^1.2.6"
-      },
-      "bin": {
-        "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/multer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-2.0.1.tgz",
-      "integrity": "sha512-Ug8bXeTIUlxurg8xLTEskKShvcKDZALo1THEX5E41pYCD2sCVub5/kIRIGqWNoqV6szyLyQKV6mD4QUrWE5GCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "append-field": "^1.0.0",
-        "busboy": "^1.6.0",
-        "concat-stream": "^2.0.0",
-        "mkdirp": "^0.5.6",
-        "object-assign": "^4.1.1",
-        "type-is": "^1.6.18",
-        "xtend": "^4.0.2"
-      },
-      "engines": {
-        "node": ">= 10.16.0"
-      }
-    },
-    "node_modules/multer/node_modules/media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
@@ -2384,7 +3005,37 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/multer/node_modules/mime-db": {
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
@@ -2393,7 +3044,7 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/multer/node_modules/mime-types": {
+    "node_modules/mime-types": {
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
@@ -2405,26 +3056,111 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/multer/node_modules/type-is": {
-      "version": "1.6.18",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
-      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/multer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-2.1.1.tgz",
+      "integrity": "sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==",
       "license": "MIT",
       "dependencies": {
-        "media-typer": "0.3.0",
-        "mime-types": "~2.1.24"
+        "append-field": "^1.0.0",
+        "busboy": "^1.6.0",
+        "concat-stream": "^2.0.0",
+        "type-is": "^1.6.18"
       },
+      "engines": {
+        "node": ">= 10.16.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.6"
       }
     },
-    "node_modules/negotiator": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
-      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+    "node_modules/nodemon": {
+      "version": "3.1.14",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.14.tgz",
+      "integrity": "sha512-jakjZi93UtB3jHMWsXL68FXSAosbLfY0In5gtKq3niLSkrWznrVBzXFNOEMJUfc9+Ke7SHWoAZsiMkNP3vq6Jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^10.2.1",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/nodemon/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-assign": {
@@ -2478,13 +3214,38 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/path-to-regexp": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.2.0.tgz",
-      "integrity": "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==",
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.13",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.13.tgz",
+      "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
+      "license": "MIT"
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/proxy-addr": {
@@ -2500,10 +3261,17 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/qs": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.0.tgz",
-      "integrity": "sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==",
+      "version": "6.14.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
+      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"
@@ -2525,15 +3293,15 @@
       }
     },
     "node_modules/raw-body": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.0.tgz",
-      "integrity": "sha512-RmkhL8CAyCRPXCE28MMH0z2PNWQBNk2Q09ZdxM9IOOXwxwZbN+qbWaatPkdkWIKL2ZVDImrN/pK5HTRz2PcS4g==",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.3.tgz",
+      "integrity": "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==",
       "license": "MIT",
       "dependencies": {
-        "bytes": "3.1.2",
-        "http-errors": "2.0.0",
-        "iconv-lite": "0.6.3",
-        "unpipe": "1.0.0"
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.4.24",
+        "unpipe": "~1.0.0"
       },
       "engines": {
         "node": ">= 0.8"
@@ -2553,20 +3321,17 @@
         "node": ">= 6"
       }
     },
-    "node_modules/router": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
-      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.4.0",
-        "depd": "^2.0.0",
-        "is-promise": "^4.0.0",
-        "parseurl": "^1.3.3",
-        "path-to-regexp": "^8.0.0"
+        "picomatch": "^2.2.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">=8.10.0"
       }
     },
     "node_modules/safe-buffer": {
@@ -2608,40 +3373,42 @@
       }
     },
     "node_modules/send": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/send/-/send-1.2.0.tgz",
-      "integrity": "sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.2.tgz",
+      "integrity": "sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==",
       "license": "MIT",
       "dependencies": {
-        "debug": "^4.3.5",
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "etag": "^1.8.1",
-        "fresh": "^2.0.0",
-        "http-errors": "^2.0.0",
-        "mime-types": "^3.0.1",
-        "ms": "^2.1.3",
-        "on-finished": "^2.4.1",
-        "range-parser": "^1.2.1",
-        "statuses": "^2.0.1"
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "~0.5.2",
+        "http-errors": "~2.0.1",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "~2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "~2.0.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/serve-static": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.0.tgz",
-      "integrity": "sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.3.tgz",
+      "integrity": "sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==",
       "license": "MIT",
       "dependencies": {
-        "encodeurl": "^2.0.0",
-        "escape-html": "^1.0.3",
-        "parseurl": "^1.3.3",
-        "send": "^1.2.0"
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "~0.19.1"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/setprototypeof": {
@@ -2649,6 +3416,45 @@
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/sharp": {
+      "version": "0.33.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
+      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "color": "^4.2.3",
+        "detect-libc": "^2.0.3",
+        "semver": "^7.6.3"
+      },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-darwin-arm64": "0.33.5",
+        "@img/sharp-darwin-x64": "0.33.5",
+        "@img/sharp-libvips-darwin-arm64": "1.0.4",
+        "@img/sharp-libvips-darwin-x64": "1.0.4",
+        "@img/sharp-libvips-linux-arm": "1.0.5",
+        "@img/sharp-libvips-linux-arm64": "1.0.4",
+        "@img/sharp-libvips-linux-s390x": "1.0.4",
+        "@img/sharp-libvips-linux-x64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
+        "@img/sharp-linux-arm": "0.33.5",
+        "@img/sharp-linux-arm64": "0.33.5",
+        "@img/sharp-linux-s390x": "0.33.5",
+        "@img/sharp-linux-x64": "0.33.5",
+        "@img/sharp-linuxmusl-arm64": "0.33.5",
+        "@img/sharp-linuxmusl-x64": "0.33.5",
+        "@img/sharp-wasm32": "0.33.5",
+        "@img/sharp-win32-ia32": "0.33.5",
+        "@img/sharp-win32-x64": "0.33.5"
+      }
     },
     "node_modules/side-channel": {
       "version": "1.1.0",
@@ -2670,13 +3476,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2722,6 +3528,28 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-swizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
+      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-arrayish": "^0.3.1"
+      }
+    },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -2749,9 +3577,9 @@
       }
     },
     "node_modules/strnum": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
-      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+      "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
       "funding": [
         {
           "type": "github",
@@ -2759,6 +3587,32 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/toidentifier": {
       "version": "1.0.1",
@@ -2769,6 +3623,16 @@
         "node": ">=0.6"
       }
     },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
+      }
+    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -2776,14 +3640,13 @@
       "license": "0BSD"
     },
     "node_modules/type-is": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.0.1.tgz",
-      "integrity": "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==",
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
       "license": "MIT",
       "dependencies": {
-        "content-type": "^1.0.5",
-        "media-typer": "^1.1.0",
-        "mime-types": "^3.0.0"
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
       },
       "engines": {
         "node": ">= 0.6"
@@ -2793,6 +3656,13 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
+      "license": "MIT"
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -2810,17 +3680,13 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/vary": {
@@ -2837,15 +3703,6 @@
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
-    },
-    "node_modules/xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4"
-      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "formidable": "^3.5.4",
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.1",
-    "sharp": "^0.33.5"
+    "sharp": "^0.33.5",
+    "uuid": "^14.0.0"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jsonwebtoken": "^9.0.2",
     "multer": "^2.0.1",
     "sharp": "^0.33.5",
-    "uuid": "^14.0.0"
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "nodemon": "^3.0.1"

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "vercel:deploy": "vercel --prod"
   },
   "engines": {
-    "node": "22.x"
+    "node": ">=22.x"
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.837.0",

--- a/public/api-docs.html
+++ b/public/api-docs.html
@@ -1,463 +1,320 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>API Documentation - Qiblat File Manager</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
-    <link rel="stylesheet" href="/css/api-docs.css">
-    <script src="/js/theme.js"></script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>API Docs — R2 Panel</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/themes/prism-tomorrow.min.css">
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/components/prism-core.min.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/prism/1.29.0/plugins/autoloader/prism-autoloader.min.js"></script>
+  <link rel="stylesheet" href="/css/main.css">
+  <script src="/js/theme.js"></script>
+  <style>
+    .method-badge { display: inline-block; padding: 2px 10px; border-radius: 6px; font-size: 12px; font-weight: 700; font-family: monospace; }
+    .method-get    { background: #dbeafe; color: #1d4ed8; }
+    .method-post   { background: #dcfce7; color: #15803d; }
+    .method-delete { background: #fee2e2; color: #b91c1c; }
+    [data-theme="dark"] .method-get    { background: #1e3a8a; color: #93c5fd; }
+    [data-theme="dark"] .method-post   { background: #14532d; color: #86efac; }
+    [data-theme="dark"] .method-delete { background: #7f1d1d; color: #fca5a5; }
+    .endpoint-path { font-family: monospace; font-size: 13px; padding: 2px 8px; border-radius: 6px; background-color: var(--bg-tertiary); color: var(--text-secondary); }
+    pre[class*="language-"] { margin: 0; border-radius: 8px; font-size: 12px; }
+    .code-label { font-size: 12px; font-weight: 600; margin-bottom: 6px; color: var(--text-secondary); }
+    .info-box { padding: 12px 16px; border-radius: 8px; border: 1px solid var(--info-border); background-color: var(--info-bg); color: var(--info-text); font-size: 13px; }
+    .warn-box { padding: 12px 16px; border-radius: 8px; border: 1px solid var(--warning-border); background-color: var(--warning-bg); color: var(--warning-text); font-size: 13px; }
+  </style>
 </head>
-<body style="background-color: var(--bg-secondary);" class="min-h-screen">
+<body class="min-h-screen" style="background-color: var(--bg-secondary); color: var(--text-primary);">
 
-    <!-- Toast container for notifications -->
-    <div id="toast-container" class="fixed bottom-5 right-5 z-50 flex flex-col gap-3"></div>
+<div id="toast-container" class="fixed bottom-5 right-5 z-50 flex flex-col gap-3"></div>
 
-    <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 max-w-7xl">
-        <!-- Header Section -->
-        <header class="shadow-md rounded-xl p-6 mb-8" style="background-color: var(--bg-primary);">
-            <div class="flex flex-col sm:flex-row justify-between items-start sm:items-center gap-4">
-                <div>
-                    <h1 class="text-2xl md:text-3xl font-bold flex items-center" style="color: var(--text-primary);">
-                        <span class="text-white bg-indigo-600 rounded-lg p-2 mr-4">
-                            <i class="fas fa-code"></i>
-                        </span>
-                        API Documentation
-                    </h1>
-                    <p class="mt-2 ml-12" style="color: var(--text-secondary);">REST API for Qiblat File Manager - External Application Integration</p>
-                </div>
-                <div class="flex items-center gap-2 flex-shrink-0 self-end sm:self-center">
-                    <a href="/webp-converter" class="bg-green-600 text-white px-4 py-2 rounded-lg hover:bg-green-700 transition-colors text-sm font-semibold flex items-center gap-2">
-                        <i class="fas fa-image"></i>
-                        <span>WebP Converter</span>
-                    </a>
-                    <a href="/stats" class="bg-blue-600 text-white px-4 py-2 rounded-lg hover:bg-blue-700 transition-colors text-sm font-semibold flex items-center gap-2">
-                        <i class="fas fa-chart-bar"></i>
-                        <span>Statistics</span>
-                    </a>
-                    <button id="generateApiKeyBtn" class="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors text-sm font-semibold flex items-center gap-2">
-                        <i class="fas fa-key"></i>
-                        <span>Show API Key</span>
-                    </button>
-                    <a href="/" class="px-4 py-2 rounded-lg transition-colors text-sm font-semibold flex items-center gap-2"
-                       style="background-color: var(--bg-secondary); color: var(--text-primary);"
-                       onmouseover="this.style.backgroundColor='var(--hover-bg)'"
-                       onmouseout="this.style.backgroundColor='var(--bg-secondary)'">
-                        <i class="fas fa-arrow-left"></i>
-                        <span>Back</span>
-                    </a>
-                </div>
-            </div>
-        </header>
+<div class="max-w-5xl mx-auto px-4 py-8 space-y-6">
 
-        <!-- API Key Section -->
-        <div id="apiKeySection" class="rounded-xl shadow-md p-6 mb-8 hidden" style="background-color: var(--bg-primary);">
-            <h2 class="text-xl font-bold mb-4 flex items-center" style="color: var(--text-primary);">
-                <i class="fas fa-key mr-3 text-yellow-500"></i>
-                API Authentication
-            </h2>
-            <div class="border rounded-lg p-4 mb-4" style="background-color: var(--warning-bg); border-color: var(--warning-border);">
-                <div class="flex items-start">
-                    <i class="fas fa-exclamation-triangle text-yellow-500 mt-1 mr-3 flex-shrink-0"></i>
-                    <div>
-                        <h3 class="font-semibold" style="color: var(--warning-text-strong);">Security Warning</h3>
-                        <p class="text-sm" style="color: var(--warning-text);">Keep your API key secure. Do not share it or commit it to version control.</p>
-                    </div>
-                </div>
-            </div>
-            <div class="space-y-4">
-                <div>
-                    <label class="block text-sm font-medium mb-2" style="color: var(--text-secondary);">Your API Key</label>
-                    <div class="flex items-center gap-2">
-                        <input type="password" id="apiKeyDisplay" readonly 
-                               class="flex-1 px-3 py-2 border rounded-lg font-mono text-sm focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500"
-                               style="background-color: var(--bg-secondary); border-color: var(--border-color); color: var(--text-primary);">
-                        <button id="toggleApiKeyBtn" class="p-2 transition-colors" style="color: var(--text-secondary);" 
-                                onmouseover="this.style.color='var(--text-primary)'"
-                                onmouseout="this.style.color='var(--text-secondary)'"
-                                aria-label="Toggle API Key Visibility">
-                            <i class="fas fa-eye"></i>
-                        </button>
-                        <button id="copyApiKeyBtn" class="bg-green-500 text-white px-4 py-2 rounded-lg hover:bg-green-600 transition-colors text-sm font-semibold flex items-center gap-2">
-                            <i class="fas fa-copy"></i>
-                            <span>Copy</span>
-                        </button>
-                    </div>
-                </div>
-            </div>
+  <!-- Header -->
+  <header class="rounded-xl shadow-sm p-5 flex flex-wrap items-center justify-between gap-4" style="background-color: var(--bg-primary);">
+    <div class="flex items-center gap-3">
+      <span class="bg-indigo-600 text-white rounded-lg p-2"><i class="fas fa-code"></i></span>
+      <div>
+        <h1 class="text-xl font-bold" style="color: var(--text-primary);">API Documentation</h1>
+        <p class="text-sm" style="color: var(--text-secondary);">R2 Storage Panel — External Integration</p>
+      </div>
+    </div>
+    <div class="flex items-center gap-2 flex-wrap">
+      <button id="generateApiKeyBtn" class="bg-indigo-600 hover:bg-indigo-700 text-white px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2 transition-colors">
+        <i class="fas fa-key"></i> Show API Key
+      </button>
+      <a href="/" class="px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2 transition-colors theme-toggle" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">
+        <i class="fas fa-arrow-left"></i> Back
+      </a>
+    </div>
+  </header>
+
+  <!-- API Key Section -->
+  <div id="apiKeySection" class="hidden rounded-xl shadow-sm p-5" style="background-color: var(--bg-primary);">
+    <h2 class="font-semibold mb-3 flex items-center gap-2" style="color: var(--text-primary);">
+      <i class="fas fa-key text-yellow-500"></i> Your API Key
+    </h2>
+    <div class="warn-box mb-4 flex items-start gap-2">
+      <i class="fas fa-exclamation-triangle mt-0.5 flex-shrink-0"></i>
+      <span>Keep your API key secret. Never commit it to version control.</span>
+    </div>
+    <div class="flex items-center gap-2">
+      <input type="password" id="apiKeyDisplay" readonly class="flex-1 px-3 py-2 border rounded-lg font-mono text-sm" style="background-color: var(--bg-secondary); border-color: var(--border-color); color: var(--text-primary);">
+      <button id="toggleApiKeyBtn" class="p-2 rounded-lg transition-colors theme-toggle" style="color: var(--text-secondary); background-color: var(--bg-tertiary);" title="Toggle visibility"><i class="fas fa-eye"></i></button>
+      <button id="copyApiKeyBtn" class="bg-green-600 hover:bg-green-700 text-white px-3 py-2 rounded-lg text-sm font-medium flex items-center gap-2 transition-colors"><i class="fas fa-copy"></i> Copy</button>
+    </div>
+  </div>
+
+  <!-- Base URL -->
+  <div class="rounded-xl shadow-sm p-5" style="background-color: var(--bg-primary);">
+    <h2 class="font-semibold mb-3" style="color: var(--text-primary);">Base URL</h2>
+    <div class="flex items-center justify-between gap-3 px-4 py-3 rounded-lg" style="background-color: var(--bg-tertiary);">
+      <code class="text-sm font-mono" style="color: var(--primary-color);" id="baseUrl">http://localhost:3000</code>
+      <button id="copyBaseUrlBtn" class="transition-colors flex-shrink-0" style="color: var(--text-tertiary);" title="Copy"><i class="fas fa-copy"></i></button>
+    </div>
+  </div>
+
+  <!-- Authentication -->
+  <div class="rounded-xl shadow-sm p-5" style="background-color: var(--bg-primary);">
+    <h2 class="font-semibold mb-4" style="color: var(--text-primary);">Authentication</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+      <div class="info-box">
+        <p class="font-semibold mb-1"><i class="fas fa-key mr-1"></i> API Key</p>
+        <p class="mb-2 text-xs">For external apps / programmatic access</p>
+        <code class="text-xs block px-2 py-1 rounded" style="background-color: var(--bg-primary);">X-API-Key: your-api-key</code>
+        <code class="text-xs block px-2 py-1 rounded mt-1" style="background-color: var(--bg-primary);">X-Bucket-ID: bucket-id</code>
+      </div>
+      <div class="info-box">
+        <p class="font-semibold mb-1"><i class="fas fa-user-shield mr-1"></i> JWT (Frontend)</p>
+        <p class="mb-2 text-xs">Session-based, set automatically after login</p>
+        <code class="text-xs block px-2 py-1 rounded" style="background-color: var(--bg-primary);">credentials: 'include'</code>
+      </div>
+    </div>
+    <div class="info-box text-xs">
+      <i class="fas fa-info-circle mr-1"></i>
+      Use <strong>X-Bucket-ID</strong> header to target a specific bucket. Omit to use the master bucket.
+    </div>
+  </div>
+
+  <!-- Endpoints -->
+  <div class="space-y-4">
+
+    <!-- Upload Single -->
+    <div class="rounded-xl shadow-sm p-5" style="background-color: var(--bg-primary);">
+      <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
+        <div class="flex items-center gap-3">
+          <span class="method-badge method-post">POST</span>
+          <span class="font-semibold" style="color: var(--text-primary);">Upload Single File</span>
         </div>
-
-        <!-- Base URL -->
-        <div class="rounded-xl shadow-md p-6 mb-8" style="background-color: var(--bg-primary);">
-            <h2 class="text-xl font-bold mb-4" style="color: var(--text-primary);">Base URL</h2>
-            <div class="rounded-lg p-4 flex items-center justify-between" style="background-color: var(--bg-secondary);">
-                <p class="font-mono text-sm overflow-x-auto" style="color: var(--text-primary);">
-                    <span style="color: var(--text-secondary);">Base URL:</span> <span class="text-indigo-600 font-semibold" id="baseUrl">http://localhost:3000/api</span>
-                </p>
-                <button id="copyBaseUrlBtn" class="ml-4 flex-shrink-0 transition-colors" style="color: var(--text-secondary);"
-                        onmouseover="this.style.color='var(--text-primary)'"
-                        onmouseout="this.style.color='var(--text-secondary)'" 
-                        aria-label="Copy Base URL">
-                    <i class="fas fa-copy"></i>
-                </button>
-            </div>
+        <span class="endpoint-path">/api/upload</span>
+      </div>
+      <p class="text-sm mb-4" style="color: var(--text-secondary);">Upload a single file. Images are auto-converted to WebP.</p>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div>
+          <p class="code-label">Request</p>
+          <pre><code class="language-bash">curl -X POST \
+  -H "X-API-Key: your-api-key" \
+  -H "X-Bucket-ID: bucket-id" \
+  -F "file=@image.jpg" \
+  http://localhost:3000/api/upload</code></pre>
         </div>
-
-        <!-- Authentication -->
-        <div class="rounded-xl shadow-md p-6 mb-8" style="background-color: var(--bg-primary);">
-            <h2 class="text-xl font-bold mb-4" style="color: var(--text-primary);">Authentication</h2>
-            <p class="mb-6" style="color: var(--text-secondary);">This API supports two types of authentication:</p>
-            
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-6">
-                <div class="p-4 rounded-lg border" style="background-color: var(--info-bg); border-color: var(--info-border);">
-                    <h3 class="font-semibold mb-2 flex items-center" style="color: var(--info-text-strong);">
-                        <i class="fas fa-key mr-2"></i>
-                        API Key Authentication
-                    </h3>
-                    <p class="text-sm mb-3" style="color: var(--info-text);">For external applications and programmatic access</p>
-                    <div class="space-y-2">
-                        <div>
-                            <h4 class="font-medium text-blue-800 text-sm">X-API-Key Header</h4>
-                            <code class="text-xs bg-blue-100 px-2 py-1 rounded">X-API-Key: your-api-key</code>
-                        </div>
-                        <div>
-                            <h4 class="font-medium text-blue-800 text-sm">Authorization Bearer</h4>
-                            <code class="text-xs bg-blue-100 px-2 py-1 rounded">Authorization: Bearer your-api-key</code>
-                        </div>
-                    </div>
-                </div>
-                
-                <div class="p-4 bg-green-50 rounded-lg border border-green-200">
-                    <h3 class="font-semibold text-green-800 mb-2 flex items-center">
-                        <i class="fas fa-user-shield mr-2"></i>
-                        JWT Authentication
-                    </h3>
-                    <p class="text-green-700 text-sm mb-3">For web frontend interface (session-based)</p>
-                    <div class="space-y-2">
-                        <div>
-                            <h4 class="font-medium text-green-800 text-sm">Cookie-based</h4>
-                            <code class="text-xs bg-green-100 px-2 py-1 rounded">credentials: 'include'</code>
-                        </div>
-                        <div>
-                            <h4 class="font-medium text-green-800 text-sm">Automatic</h4>
-                            <code class="text-xs bg-green-100 px-2 py-1 rounded">Set after login</code>
-                        </div>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
-                <div>
-                    <h3 class="font-semibold text-gray-700 mb-2">Example: API Key</h3>
-                    <pre><code class="language-bash">curl -H "X-API-Key: your-api-key" \
-    -X POST \
-    http://localhost:3000/api/upload-webp</code></pre>
-                </div>
-                <div>
-                    <h3 class="font-semibold text-gray-700 mb-2">Example: Frontend JWT</h3>
-                    <pre><code class="language-javascript">fetch('/api/upload-webp', {
-  method: 'POST',
-  body: formData,
-  credentials: 'include'
-})</code></pre>
-                </div>
-            </div>
-        </div>
-
-        <!-- Endpoints -->
-        <div class="space-y-6">
-            <!-- Upload Single File -->
-            <div class="endpoint-card bg-white rounded-xl shadow-md p-6">
-                <div class="flex flex-col md:flex-row items-start md:items-center justify-between mb-4 gap-2">
-                    <h3 class="text-xl font-bold text-gray-800 flex items-center">
-                        <span class="bg-green-100 text-green-800 px-2.5 py-1 rounded-md text-sm font-mono mr-4">POST</span>
-                        Upload Single File
-                    </h3>
-                    <span class="text-sm text-gray-500 font-mono bg-gray-100 px-2 py-1 rounded-md">/api/upload</span>
-                </div>
-                <p class="text-gray-600 mb-6">Upload a single file to R2 storage. Image files will be automatically converted to WebP format for optimization.</p>
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Request</h4>
-                        <pre><code class="language-bash">curl -X POST \
- -H "X-API-Key: your-api-key" \
- -F "file=@/path/to/your/file.jpg" \
- http://localhost:3000/api/upload</code></pre>
-                    </div>
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Response</h4>
-                        <pre><code class="language-json">{
-  "success": true,
-  "message": "File uploaded successfully",
+        <div>
+          <p class="code-label">Response</p>
+          <pre><code class="language-json">{
+  "meta": { "code": 200, "status": "success" },
   "data": {
-    "filename": "1640995200000-image.jpg",
-    "originalName": "image.jpg",
-    "key": "1640995200000-image.jpg",
+    "filename": "1640995200-image.webp",
+    "key": "1640995200-image.webp",
     "size": 245760,
-    "contentType": "image/jpeg",
-    "publicUrl": "https://...",
-    "downloadUrl": "/api/files/download/...",
-    "uploadedAt": "2023-12-31T12:00:00.000Z"
+    "contentType": "image/webp",
+    "publicUrl": "https://cdn.example.com/...",
+    "downloadUrl": "/r2/download/..."
   }
 }</code></pre>
-                    </div>
-                </div>
-            </div>
+        </div>
+      </div>
+    </div>
 
-            <!-- More endpoints... -->
-             <div class="endpoint-card bg-white rounded-xl shadow-md p-6">
-                <div class="flex flex-col md:flex-row items-start md:items-center justify-between mb-4 gap-2">
-                    <h3 class="text-xl font-bold text-gray-800 flex items-center">
-                        <span class="bg-green-100 text-green-800 px-2.5 py-1 rounded-md text-sm font-mono mr-4">POST</span>
-                        Upload Multiple Files
-                    </h3>
-                    <span class="text-sm text-gray-500 font-mono bg-gray-100 px-2 py-1 rounded-md">/api/upload-multiple</span>
-                </div>
-                <p class="text-gray-600 mb-6">Upload multiple files (max 10) to R2 storage. Image files will be automatically converted to WebP format for optimization.</p>
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Request</h4>
-                        <pre><code class="language-bash">curl -X POST \
- -H "X-API-Key: your-api-key" \
- -F "files=@/path/to/file1.jpg" \
- -F "files=@/path/to/file2.png" \
- http://localhost:3000/api/upload-multiple</code></pre>
-                    </div>
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Response</h4>
-                        <pre><code class="language-json">{
-  "success": true,
-  "message": "2 files uploaded successfully",
+    <!-- Upload Multiple -->
+    <div class="rounded-xl shadow-sm p-5" style="background-color: var(--bg-primary);">
+      <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
+        <div class="flex items-center gap-3">
+          <span class="method-badge method-post">POST</span>
+          <span class="font-semibold" style="color: var(--text-primary);">Upload Multiple Files</span>
+        </div>
+        <span class="endpoint-path">/api/upload-multiple</span>
+      </div>
+      <p class="text-sm mb-4" style="color: var(--text-secondary);">Upload up to 10 files at once.</p>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div>
+          <p class="code-label">Request</p>
+          <pre><code class="language-bash">curl -X POST \
+  -H "X-API-Key: your-api-key" \
+  -H "X-Bucket-ID: bucket-id" \
+  -F "files=@file1.jpg" \
+  -F "files=@file2.png" \
+  http://localhost:3000/api/upload-multiple</code></pre>
+        </div>
+        <div>
+          <p class="code-label">Response</p>
+          <pre><code class="language-json">{
+  "meta": { "code": 200, "status": "success" },
   "data": {
-    "uploaded": [
-      {
-        "filename": "1640995200000-abc-image.webp",
-        "originalName": "image.jpg",
-        "key": "1640995200000-abc-image.webp",
-        "size": 245760,
-        "contentType": "image/webp",
-        "publicUrl": "https://...",
-        "downloadUrl": "/r2/download/...",
-        "uploadedAt": "2023-12-31T12:00:00.000Z"
-      }
-    ],
+    "uploaded": [...],
     "errors": [],
     "summary": {
-      "total": 2,
-      "successful": 2,
-      "failed": 0
+      "total": 2, "successful": 2, "failed": 0
     }
   }
 }</code></pre>
-                    </div>
-                </div>
-            </div>
+        </div>
+      </div>
+    </div>
 
-             <div class="endpoint-card bg-white rounded-xl shadow-md p-6">
-                <div class="flex flex-col md:flex-row items-start md:items-center justify-between mb-4 gap-2">
-                    <h3 class="text-xl font-bold text-gray-800 flex items-center">
-                        <span class="bg-purple-100 text-purple-800 px-2.5 py-1 rounded-md text-sm font-mono mr-4">POST</span>
-                        Upload & Convert to WebP
-                    </h3>
-                    <span class="text-sm text-gray-500 font-mono bg-gray-100 px-2 py-1 rounded-md">/api/files/upload-webp (API) | /r2/upload-webp (Frontend)</span>
-                </div>
-                <p class="text-gray-600 mb-6">Upload image and automatically convert to WebP format for better web performance. Supports both JWT (frontend) and API Key (external apps) authentication.</p>
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Request (API Key - External Apps)</h4>
-                        <pre><code class="language-bash">curl -X POST \
- -H "X-API-Key: your-api-key" \
- -F "image=@/path/to/image.jpg" \
- -F "quality=80" \
- http://localhost:3000/api/files/upload-webp</code></pre>
-                        <h4 class="font-semibold text-gray-700 mb-2 mt-4">Request (Frontend/JWT)</h4>
-                        <pre><code class="language-javascript">// Frontend with JWT cookie
-fetch('/r2/upload-webp', {
-  method: 'POST',
-  body: formData,
-  credentials: 'include'
-})</code></pre>
-                        <div class="mt-4 p-4 bg-blue-50 rounded-lg">
-                            <h5 class="font-semibold text-blue-800 mb-2">Parameters</h5>
-                            <ul class="text-sm text-blue-700 space-y-1">
-                                <li><strong>image:</strong> Image file (required) - JPEG, PNG, GIF, BMP, TIFF, WebP</li>
-                                <li><strong>quality:</strong> Number (optional, default: 80) - WebP quality (10-100)</li>
-                            </ul>
-                        </div>
-                    </div>
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Response</h4>
-                        <pre><code class="language-json">{
-  "success": true,
-  "message": "Image uploaded and converted successfully",
-  "authType": "apikey",
-  "file": {
-    "key": "webp/1698765432-example.webp",
-    "originalName": "example.jpg",
-    "convertedName": "example.webp",
-    "size": 245760,
-    "contentType": "image/webp",
-    "url": "https://your-r2-domain.com/webp/1698765432-example.webp",
-    "wasConverted": true,
-    "originalFormat": "image/jpeg",
-    "uploadedAt": "2024-12-28T10:30:00.000Z"
-  }
-}</code></pre>
-                        <div class="mt-4 p-4 bg-green-50 rounded-lg">
-                            <h5 class="font-semibold text-green-800 mb-2">Benefits</h5>
-                            <ul class="text-sm text-green-700 space-y-1">
-                                <li>• 25-35% smaller file sizes</li>
-                                <li>• Faster loading times</li>
-                                <li>• Modern browser support</li>
-                                <li>• Quality preservation</li>
-                            </ul>
-                        </div>
-                    </div>
-                </div>
-            </div>
-
-             <div class="endpoint-card bg-white rounded-xl shadow-md p-6">
-                <div class="flex flex-col md:flex-row items-start md:items-center justify-between mb-4 gap-2">
-                    <h3 class="text-xl font-bold text-gray-800 flex items-center">
-                        <span class="bg-blue-100 text-blue-800 px-2.5 py-1 rounded-md text-sm font-mono mr-4">GET</span>
-                        List Files
-                    </h3>
-                    <span class="text-sm text-gray-500 font-mono bg-gray-100 px-2 py-1 rounded-md">/api/files</span>
-                </div>
-                <p class="text-gray-600 mb-6">Get a list of all uploaded files with pagination support.</p>
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Request</h4>
-                        <pre><code class="language-bash">curl -H "X-API-Key: your-api-key" \
- "http://localhost:3000/api/files?limit=50&prefix=image"</code></pre>
-                        <h5 class="font-semibold text-gray-700 mt-4 mb-2">Query Parameters</h5>
-                        <ul class="text-sm text-gray-600 space-y-2 list-disc list-inside">
-                            <li><code class="bg-gray-200 text-gray-800 px-1.5 py-0.5 rounded-md text-xs">limit</code> - Number of files to return (default: 100)</li>
-                            <li><code class="bg-gray-200 text-gray-800 px-1.5 py-0.5 rounded-md text-xs">token</code> - Next page token for pagination</li>
-                            <li><code class="bg-gray-200 text-gray-800 px-1.5 py-0.5 rounded-md text-xs">prefix</code> - Filter files by prefix</li>
-                        </ul>
-                    </div>
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Response</h4>
-                        <pre><code class="language-json">{
-  "success": true,
+    <!-- List Files -->
+    <div class="rounded-xl shadow-sm p-5" style="background-color: var(--bg-primary);">
+      <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
+        <div class="flex items-center gap-3">
+          <span class="method-badge method-get">GET</span>
+          <span class="font-semibold" style="color: var(--text-primary);">List Files</span>
+        </div>
+        <span class="endpoint-path">/api/files</span>
+      </div>
+      <p class="text-sm mb-3" style="color: var(--text-secondary);">List files with pagination. Query params: <code class="endpoint-path">limit</code> <code class="endpoint-path">token</code> <code class="endpoint-path">prefix</code></p>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div>
+          <p class="code-label">Request</p>
+          <pre><code class="language-bash">curl -H "X-API-Key: your-api-key" \
+  -H "X-Bucket-ID: bucket-id" \
+  "http://localhost:3000/api/files?limit=50"</code></pre>
+        </div>
+        <div>
+          <p class="code-label">Response</p>
+          <pre><code class="language-json">{
+  "meta": { "code": 200, "status": "success" },
   "data": {
     "files": [
       {
-        "key": "1640995200000-image.jpg",
+        "key": "image.webp",
         "size": 245760,
-        "lastModified": "2023-12-31T12:00:00.000Z",
         "publicUrl": "https://...",
-        "downloadUrl": "/api/files/download/..."
+        "presignedUrl": "https://...",
+        "downloadUrl": "/r2/download/..."
       }
     ],
-    "pagination": {
-      "nextToken": null,
-      "isTruncated": false,
-      "count": 1
-    }
+    "pagination": { "nextToken": null }
   }
 }</code></pre>
-                    </div>
-                </div>
-            </div>
-
-            <div class="endpoint-card bg-white rounded-xl shadow-md p-6">
-                <div class="flex flex-col md:flex-row items-start md:items-center justify-between mb-4 gap-2">
-                    <h3 class="text-xl font-bold text-gray-800 flex items-center">
-                        <span class="bg-red-100 text-red-800 px-2.5 py-1 rounded-md text-sm font-mono mr-4">DELETE</span>
-                        Delete File
-                    </h3>
-                        <span class="text-sm text-gray-500 font-mono bg-gray-100 px-2 py-1 rounded-md">/api/files/:key</span>
-                </div>
-                <p class="text-gray-600 mb-6">Delete a file from R2 storage by its key.</p>
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Request</h4>
-                        <pre><code class="language-bash">curl -X DELETE \
- -H "X-API-Key: your-api-key" \
- http://localhost:3000/api/files/1640995200000-image.jpg</code></pre>
-                    </div>
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Response</h4>
-                        <pre><code class="language-json">{
-  "success": true,
-  "message": "File deleted successfully",
-  "data": {
-    "key": "1640995200000-image.jpg"
-  }
-}</code></pre>
-                    </div>
-                </div>
-            </div>
-            
-            <div class="endpoint-card bg-white rounded-xl shadow-md p-6">
-                <div class="flex flex-col md:flex-row items-start md:items-center justify-between mb-4 gap-2">
-                    <h3 class="text-xl font-bold text-gray-800 flex items-center">
-                        <span class="bg-purple-100 text-purple-800 px-2.5 py-1 rounded-md text-sm font-mono mr-4">GET</span>
-                        API Information
-                    </h3>
-                    <span class="text-sm text-gray-500 font-mono bg-gray-100 px-2 py-1 rounded-md">/api/info</span>
-                </div>
-                <p class="text-gray-600 mb-6">Get API information and available endpoints.</p>
-                <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Request</h4>
-                        <pre><code class="language-bash">curl -H "X-API-Key: your-api-key" \
- http://localhost:3000/api/info</code></pre>
-                    </div>
-                    <div>
-                        <h4 class="font-semibold text-gray-700 mb-2">Response</h4>
-                        <pre><code class="language-json">{
-  "success": true,
-  "data": {
-    "name": "R2 File Manager API",
-    "version": "1.0.0",
-    "endpoints": {...},
-    "authentication": "API Key required",
-    "maxFileSize": "50MB per file"
-  }
-}</code></pre>
-                    </div>
-                </div>
-            </div>
-
         </div>
-
-        <!-- Error Responses -->
-        <div class="bg-white rounded-xl shadow-md p-6 mt-8">
-            <h2 class="text-xl font-bold text-gray-800 mb-4">Error Responses</h2>
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-                <div>
-                    <h3 class="font-semibold text-gray-700 mb-2">401 Unauthorized</h3>
-                    <pre><code class="language-json">{
-  "error": "API key required",
-  "message": "Provide API key in..."
-}</code></pre>
-                </div>
-                <div>
-                    <h3 class="font-semibold text-gray-700 mb-2">400 Bad Request</h3>
-                    <pre><code class="language-json">{
-  "error": "No file uploaded",
-  "message": "Please provide a file..."
-}</code></pre>
-                </div>
-                <div>
-                    <h3 class="font-semibold text-gray-700 mb-2">500 Internal Server Error</h3>
-                    <pre><code class="language-json">{
-  "success": false,
-  "error": "Upload failed",
-  "message": "Detailed error message"
-}</code></pre>
-                </div>
-            </div>
-        </div>
+      </div>
     </div>
 
-    <script src="/js/api-docs.js"></script>
+    <!-- Delete File -->
+    <div class="rounded-xl shadow-sm p-5" style="background-color: var(--bg-primary);">
+      <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
+        <div class="flex items-center gap-3">
+          <span class="method-badge method-delete">DELETE</span>
+          <span class="font-semibold" style="color: var(--text-primary);">Delete File</span>
+        </div>
+        <span class="endpoint-path">/api/files/:key</span>
+      </div>
+      <p class="text-sm mb-4" style="color: var(--text-secondary);">Delete a file by its key.</p>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div>
+          <p class="code-label">Request</p>
+          <pre><code class="language-bash">curl -X DELETE \
+  -H "X-API-Key: your-api-key" \
+  -H "X-Bucket-ID: bucket-id" \
+  http://localhost:3000/api/files/image.webp</code></pre>
+        </div>
+        <div>
+          <p class="code-label">Response</p>
+          <pre><code class="language-json">{
+  "meta": { "code": 200, "status": "success",
+            "message": "File deleted successfully" },
+  "data": { "key": "image.webp" }
+}</code></pre>
+        </div>
+      </div>
+    </div>
+
+    <!-- Stats -->
+    <div class="rounded-xl shadow-sm p-5" style="background-color: var(--bg-primary);">
+      <div class="flex flex-wrap items-center justify-between gap-2 mb-3">
+        <div class="flex items-center gap-3">
+          <span class="method-badge method-get">GET</span>
+          <span class="font-semibold" style="color: var(--text-primary);">Storage Stats</span>
+        </div>
+        <span class="endpoint-path">/api/stats</span>
+      </div>
+      <p class="text-sm mb-4" style="color: var(--text-secondary);">Get storage usage statistics for the active bucket.</p>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        <div>
+          <p class="code-label">Request</p>
+          <pre><code class="language-bash">curl -H "X-API-Key: your-api-key" \
+  -H "X-Bucket-ID: bucket-id" \
+  http://localhost:3000/api/stats</code></pre>
+        </div>
+        <div>
+          <p class="code-label">Response</p>
+          <pre><code class="language-json">{
+  "meta": { "code": 200, "status": "success" },
+  "data": {
+    "totalSize": 1048576,
+    "totalFiles": 42,
+    "fileTypes": { "image": 30, "doc": 12 }
+  }
+}</code></pre>
+        </div>
+      </div>
+    </div>
+
+  </div>
+
+  <!-- Error Responses -->
+  <div class="rounded-xl shadow-sm p-5" style="background-color: var(--bg-primary);">
+    <h2 class="font-semibold mb-4" style="color: var(--text-primary);">Error Responses</h2>
+    <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+      <div>
+        <p class="code-label">401 Unauthorized</p>
+        <pre><code class="language-json">{
+  "meta": {
+    "code": 401,
+    "status": "error",
+    "message": "API key required"
+  },
+  "data": null
+}</code></pre>
+      </div>
+      <div>
+        <p class="code-label">400 Bad Request</p>
+        <pre><code class="language-json">{
+  "meta": {
+    "code": 400,
+    "status": "error",
+    "message": "No file uploaded"
+  },
+  "data": null
+}</code></pre>
+      </div>
+      <div>
+        <p class="code-label">500 Server Error</p>
+        <pre><code class="language-json">{
+  "meta": {
+    "code": 500,
+    "status": "error",
+    "message": "Upload failed"
+  },
+  "data": null
+}</code></pre>
+      </div>
+    </div>
+  </div>
+
+</div>
+
+<script src="/js/api-docs.js"></script>
 </body>
 </html>

--- a/public/bucket-selector.html
+++ b/public/bucket-selector.html
@@ -36,6 +36,9 @@
     <button onclick="openCreateModal()" class="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-medium transition-colors">
       <i class="fas fa-plus"></i> Add Bucket
     </button>
+    <button onclick="openImportModal()" class="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-orange-500 hover:bg-orange-600 text-white rounded-xl font-medium transition-colors">
+      <i class="fas fa-cloud-download-alt"></i> Import from Cloudflare
+    </button>
     <button onclick="logout()" class="px-4 py-3 text-gray-500 dark:text-gray-400 hover:text-red-500 border border-gray-200 dark:border-gray-700 rounded-xl transition-colors">
       <i class="fas fa-sign-out-alt"></i>
     </button>
@@ -95,6 +98,70 @@
         </button>
       </div>
     </form>
+  </div>
+</div>
+
+<!-- Import from Cloudflare Modal -->
+<div id="import-modal" class="fixed inset-0 bg-black/50 z-50 hidden flex items-center justify-center p-4">
+  <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] flex flex-col">
+    <div class="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-700">
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Import from Cloudflare</h2>
+      <button onclick="closeImportModal()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
+        <i class="fas fa-times"></i>
+      </button>
+    </div>
+
+    <!-- Step 1: CF bucket list -->
+    <div id="import-step-1" class="p-6 flex-1 overflow-y-auto">
+      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        <i class="fas fa-info-circle mr-1 text-blue-400"></i>
+        Bucket names & endpoints are fetched from Cloudflare. You still need to provide Access Key + Secret Key per bucket.
+      </p>
+      <div id="cf-bucket-list" class="space-y-2">
+        <div class="flex items-center justify-center py-8">
+          <i class="fas fa-spinner fa-spin text-gray-400 text-2xl"></i>
+        </div>
+      </div>
+    </div>
+
+    <!-- Step 2: Fill credentials for selected bucket -->
+    <div id="import-step-2" class="p-6 hidden">
+      <div class="flex items-center gap-2 mb-4">
+        <button onclick="backToStep1()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
+          <i class="fas fa-arrow-left"></i>
+        </button>
+        <h3 class="font-semibold text-gray-900 dark:text-white">Add credentials for <span id="import-bucket-name-label" class="text-blue-600"></span></h3>
+      </div>
+      <form id="import-form" onsubmit="submitImport(event)" class="space-y-4">
+        <input type="hidden" id="i-name">
+        <input type="hidden" id="i-endpoint">
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Access Key ID</label>
+            <input id="i-access-key" type="text" placeholder="Access Key ID" required
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Secret Access Key</label>
+            <input id="i-secret-key" type="password" placeholder="Secret Access Key" required
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+          </div>
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Public URL <span class="text-gray-400 font-normal">(optional)</span></label>
+          <input id="i-public-url" type="url" placeholder="https://pub-xxx.r2.dev"
+            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+        </div>
+        <div class="flex gap-3 pt-2">
+          <button type="button" onclick="backToStep1()" class="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+            Back
+          </button>
+          <button type="submit" id="import-btn" class="flex-1 px-4 py-2 bg-orange-500 hover:bg-orange-600 text-white rounded-lg font-medium transition-colors">
+            <span id="import-btn-text">Add Bucket</span>
+          </button>
+        </div>
+      </form>
+    </div>
   </div>
 </div>
 

--- a/public/bucket-selector.html
+++ b/public/bucket-selector.html
@@ -52,7 +52,7 @@
   </div>
 
   <!-- Actions -->
-  <div class="flex gap-3">
+  <div id="bucket-actions" class="flex gap-3">
     <button onclick="openCreateModal()" class="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-medium transition-colors">
       <i class="fas fa-plus"></i> Add Bucket
     </button>

--- a/public/bucket-selector.html
+++ b/public/bucket-selector.html
@@ -61,22 +61,33 @@
           class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
         <p class="text-xs text-gray-400 mt-1">Lowercase letters, numbers, hyphens (3–63 chars)</p>
       </div>
-      <div>
-        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">R2 Endpoint</label>
-        <input id="f-endpoint" type="url" placeholder="https://account-id.r2.cloudflarestorage.com" required
-          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+
+      <!-- Shown only when shared creds not configured -->
+      <div id="credential-fields">
+        <div class="mb-3">
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">R2 Endpoint</label>
+          <input id="f-endpoint" type="url" placeholder="https://account-id.r2.cloudflarestorage.com"
+            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+        </div>
+        <div class="grid grid-cols-2 gap-3">
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Access Key ID</label>
+            <input id="f-access-key" type="text" placeholder="Access Key ID"
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+          </div>
+          <div>
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Secret Access Key</label>
+            <input id="f-secret-key" type="password" placeholder="Secret Access Key"
+              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+          </div>
+        </div>
       </div>
-      <div class="grid grid-cols-2 gap-3">
-        <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Access Key ID</label>
-          <input id="f-access-key" type="text" placeholder="Access Key ID" required
-            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
-        </div>
-        <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Secret Access Key</label>
-          <input id="f-secret-key" type="password" placeholder="Secret Access Key" required
-            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
-        </div>
+
+      <!-- Shown when shared creds are configured -->
+      <div id="credential-hint" class="hidden p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
+        <p class="text-sm text-green-700 dark:text-green-400">
+          <i class="fas fa-bolt mr-1"></i> Using shared R2 credentials from env. No need to enter keys.
+        </p>
       </div>
       <div>
         <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Public URL <span class="text-gray-400 font-normal">(optional)</span></label>

--- a/public/bucket-selector.html
+++ b/public/bucket-selector.html
@@ -23,25 +23,23 @@
       border-color: #4b5563 !important;
     }
     /* Fix text visibility on bucket selector page */
-    body { color: #111827; }
-    [data-theme="dark"] body { color: #f9fafb; }
-    .bucket-card-name { color: #111827 !important; }
-    [data-theme="dark"] .bucket-card-name { color: #f9fafb !important; }
-    .bucket-card-sub { color: #6b7280 !important; }
+    body { color: var(--text-primary); }
+    .bucket-card-name { color: var(--text-primary) !important; }
+    .bucket-card-sub { color: var(--text-secondary) !important; }
   </style>
 </head>
-<body class="bg-gray-50 dark:bg-gray-900 min-h-screen flex flex-col items-center justify-center p-4">
+<body class="min-h-screen flex flex-col items-center justify-center p-4" style="background-color: var(--bg-secondary);">
 
 <div id="toast-container" class="fixed bottom-5 right-5 z-[100] flex flex-col gap-3"></div>
 
 <div class="w-full max-w-2xl">
   <!-- Header -->
   <div class="text-center mb-8">
-    <div class="inline-flex items-center justify-center w-16 h-16 bg-blue-100 dark:bg-blue-900 rounded-2xl mb-4">
-      <i class="fas fa-database text-blue-600 dark:text-blue-400 text-2xl"></i>
+    <div class="inline-flex items-center justify-center w-16 h-16 rounded-2xl mb-4" style="background-color: var(--bg-tertiary);">
+      <i class="fas fa-database text-2xl" style="color: var(--primary-color);"></i>
     </div>
-    <h1 class="text-2xl font-bold" style="color:#111827">Select Bucket</h1>
-    <p class="mt-1" style="color:#6b7280">Choose a bucket to manage or create a new one</p>
+    <h1 class="text-2xl font-bold" style="color: var(--text-primary)">Select Bucket</h1>
+    <p class="mt-1" style="color: var(--text-secondary)">Choose a bucket to manage or create a new one</p>
   </div>
 
   <!-- Bucket List -->
@@ -59,7 +57,7 @@
     <button onclick="openImportModal()" class="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-orange-500 hover:bg-orange-600 text-white rounded-xl font-medium transition-colors">
       <i class="fas fa-cloud-download-alt"></i> Import from Cloudflare
     </button>
-    <button onclick="logout()" class="px-4 py-3 text-gray-500 dark:text-gray-400 hover:text-red-500 border border-gray-200 dark:border-gray-700 rounded-xl transition-colors">
+    <button onclick="logout()" class="px-4 py-3 border rounded-xl transition-colors" style="color: var(--text-secondary); border-color: var(--border-color);">
       <i class="fas fa-sign-out-alt"></i>
     </button>
   </div>
@@ -67,61 +65,61 @@
 
 <!-- Create Bucket Modal -->
 <div id="create-modal" class="fixed inset-0 bg-black/50 z-50 hidden flex items-center justify-center p-4">
-  <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-lg">
-    <div class="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-700">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Add Bucket</h2>
-      <button onclick="closeCreateModal()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
+  <div class="rounded-2xl shadow-xl w-full max-w-lg" style="background-color: var(--bg-primary);">
+    <div class="flex items-center justify-between p-6" style="border-bottom: 1px solid var(--border-color);">
+      <h2 class="text-lg font-semibold" style="color: var(--text-primary);">Add Bucket</h2>
+      <button onclick="closeCreateModal()" class="hover:text-gray-600" style="color: var(--text-tertiary);">
         <i class="fas fa-times"></i>
       </button>
     </div>
     <form id="create-form" onsubmit="submitCreate(event)" class="p-6 space-y-4">
       <div>
-        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Bucket Name</label>
+        <label class="block text-sm font-medium mb-1" style="color: var(--text-secondary);">Bucket Name</label>
         <input id="f-name" type="text" placeholder="my-bucket" required
-          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
-        <p class="text-xs text-gray-400 mt-1">Lowercase letters, numbers, hyphens (3–63 chars)</p>
+          class="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 outline-none" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
+        <p class="text-xs mt-1" style="color: var(--text-tertiary);">Lowercase letters, numbers, hyphens (3–63 chars)</p>
       </div>
 
       <!-- Shown only when shared creds not configured -->
       <div id="credential-fields">
         <div class="mb-3">
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">R2 Endpoint</label>
+          <label class="block text-sm font-medium mb-1" style="color: var(--text-secondary);">R2 Endpoint</label>
           <input id="f-endpoint" type="url" placeholder="https://account-id.r2.cloudflarestorage.com"
-            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+            class="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 outline-none" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
         </div>
         <div class="grid grid-cols-2 gap-3">
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Access Key ID</label>
+            <label class="block text-sm font-medium mb-1" style="color: var(--text-secondary);">Access Key ID</label>
             <input id="f-access-key" type="text" placeholder="Access Key ID"
-              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+              class="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 outline-none" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Secret Access Key</label>
+            <label class="block text-sm font-medium mb-1" style="color: var(--text-secondary);">Secret Access Key</label>
             <input id="f-secret-key" type="password" placeholder="Secret Access Key"
-              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+              class="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 outline-none" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
           </div>
         </div>
       </div>
 
       <!-- Shown when shared creds are configured -->
       <div id="credential-hint" class="hidden p-3 bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 rounded-lg">
-        <p class="text-sm text-green-700 dark:text-green-400">
+        <p class="text-sm" style="color: var(--text-secondary);">
           <i class="fas fa-bolt mr-1"></i> Using shared R2 credentials from env. No need to enter keys.
         </p>
       </div>
       <div>
-        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Public URL <span class="text-gray-400 font-normal">(optional)</span></label>
+        <label class="block text-sm font-medium mb-1" style="color: var(--text-secondary);">Public URL <span class="font-normal" style="color: var(--text-tertiary);">(optional)</span></label>
         <input id="f-public-url" type="url" placeholder="https://pub-xxx.r2.dev"
-          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+          class="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 outline-none" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
       </div>
       <div class="flex items-center gap-2">
         <input id="f-create-cf" type="checkbox" class="rounded">
-        <label for="f-create-cf" class="text-sm text-gray-700 dark:text-gray-300">
-          Also create bucket on Cloudflare R2 <span class="text-gray-400">(requires CF_ACCOUNT_ID + CF_API_TOKEN in env)</span>
+        <label for="f-create-cf" class="text-sm" style="color: var(--text-secondary);">
+          Also create bucket on Cloudflare R2 <span style="color: var(--text-tertiary);">(requires CF_ACCOUNT_ID + CF_API_TOKEN in env)</span>
         </label>
       </div>
       <div class="flex gap-3 pt-2">
-        <button type="button" onclick="closeCreateModal()" class="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+        <button type="button" onclick="closeCreateModal()" class="flex-1 px-4 py-2 border rounded-lg transition-colors" style="border-color: var(--border-color); color: var(--text-secondary); background-color: var(--bg-secondary);">
           Cancel
         </button>
         <button type="submit" id="create-btn" class="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors">
@@ -134,17 +132,17 @@
 
 <!-- Import from Cloudflare Modal -->
 <div id="import-modal" class="fixed inset-0 bg-black/50 z-50 hidden flex items-center justify-center p-4">
-  <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] flex flex-col">
-    <div class="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-700">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Import from Cloudflare</h2>
-      <button onclick="closeImportModal()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
+  <div class="rounded-2xl shadow-xl w-full max-w-lg max-h-[90vh] flex flex-col" style="background-color: var(--bg-primary);">
+    <div class="flex items-center justify-between p-6" style="border-bottom: 1px solid var(--border-color);">
+      <h2 class="text-lg font-semibold" style="color: var(--text-primary);">Import from Cloudflare</h2>
+      <button onclick="closeImportModal()" style="color: var(--text-tertiary);">
         <i class="fas fa-times"></i>
       </button>
     </div>
 
     <!-- Step 1: CF bucket list -->
     <div id="import-step-1" class="p-6 flex-1 overflow-y-auto">
-      <p id="import-hint" class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+      <p id="import-hint" class="text-sm mb-4" style="color: var(--text-secondary);">
         <i class="fas fa-spinner fa-spin mr-1"></i> Checking credentials...
       </p>
       <div id="cf-bucket-list" class="space-y-2">
@@ -160,30 +158,30 @@
         <button onclick="backToStep1()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
           <i class="fas fa-arrow-left"></i>
         </button>
-        <h3 class="font-semibold text-gray-900 dark:text-white">Add credentials for <span id="import-bucket-name-label" class="text-blue-600"></span></h3>
+        <h3 class="font-semibold" style="color: var(--text-primary);">Add credentials for <span id="import-bucket-name-label" class="text-blue-600"></span></h3>
       </div>
       <form id="import-form" onsubmit="submitImport(event)" class="space-y-4">
         <input type="hidden" id="i-name">
         <input type="hidden" id="i-endpoint">
         <div class="grid grid-cols-2 gap-3">
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Access Key ID</label>
+            <label class="block text-sm font-medium mb-1" style="color: var(--text-secondary);">Access Key ID</label>
             <input id="i-access-key" type="text" placeholder="Access Key ID" required
-              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+              class="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 outline-none" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
           </div>
           <div>
-            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Secret Access Key</label>
+            <label class="block text-sm font-medium mb-1" style="color: var(--text-secondary);">Secret Access Key</label>
             <input id="i-secret-key" type="password" placeholder="Secret Access Key" required
-              class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+              class="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 outline-none" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
           </div>
         </div>
         <div>
-          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Public URL <span class="text-gray-400 font-normal">(optional)</span></label>
+          <label class="block text-sm font-medium mb-1" style="color: var(--text-secondary);">Public URL <span class="font-normal" style="color: var(--text-tertiary);">(optional)</span></label>
           <input id="i-public-url" type="url" placeholder="https://pub-xxx.r2.dev"
-            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+            class="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 outline-none" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
         </div>
         <div class="flex gap-3 pt-2">
-          <button type="button" onclick="backToStep1()" class="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+          <button type="button" onclick="backToStep1()" class="flex-1 px-4 py-2 border rounded-lg transition-colors" style="border-color: var(--border-color); color: var(--text-secondary); background-color: var(--bg-secondary);">
             Back
           </button>
           <button type="submit" id="import-btn" class="flex-1 px-4 py-2 bg-orange-500 hover:bg-orange-600 text-white rounded-lg font-medium transition-colors">

--- a/public/bucket-selector.html
+++ b/public/bucket-selector.html
@@ -113,9 +113,8 @@
 
     <!-- Step 1: CF bucket list -->
     <div id="import-step-1" class="p-6 flex-1 overflow-y-auto">
-      <p class="text-sm text-gray-500 dark:text-gray-400 mb-4">
-        <i class="fas fa-info-circle mr-1 text-blue-400"></i>
-        Bucket names & endpoints are fetched from Cloudflare. You still need to provide Access Key + Secret Key per bucket.
+      <p id="import-hint" class="text-sm text-gray-500 dark:text-gray-400 mb-4">
+        <i class="fas fa-spinner fa-spin mr-1"></i> Checking credentials...
       </p>
       <div id="cf-bucket-list" class="space-y-2">
         <div class="flex items-center justify-center py-8">

--- a/public/bucket-selector.html
+++ b/public/bucket-selector.html
@@ -9,6 +9,20 @@
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
   <link rel="stylesheet" href="/css/main.css">
   <script src="/js/theme.js"></script>
+  <style>
+    /* Ensure inputs are always readable regardless of theme */
+    #create-modal input, #import-modal input {
+      background-color: #ffffff !important;
+      color: #111827 !important;
+      border-color: #d1d5db !important;
+    }
+    [data-theme="dark"] #create-modal input,
+    [data-theme="dark"] #import-modal input {
+      background-color: #374151 !important;
+      color: #f9fafb !important;
+      border-color: #4b5563 !important;
+    }
+  </style>
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 min-h-screen flex flex-col items-center justify-center p-4">
 

--- a/public/bucket-selector.html
+++ b/public/bucket-selector.html
@@ -193,6 +193,30 @@
   </div>
 </div>
 
+<!-- Edit Public URL Modal -->
+<div id="edit-url-modal" class="fixed inset-0 bg-black/50 z-50 hidden flex items-center justify-center p-4">
+  <div class="rounded-2xl shadow-xl w-full max-w-md" style="background-color: var(--bg-primary);">
+    <div class="flex items-center justify-between p-5" style="border-bottom: 1px solid var(--border-color);">
+      <h2 class="text-base font-semibold" style="color: var(--text-primary);">Set Public URL</h2>
+      <button onclick="closeEditUrlModal()" style="color: var(--text-tertiary);"><i class="fas fa-times"></i></button>
+    </div>
+    <div class="p-5 space-y-4">
+      <p class="text-sm" style="color: var(--text-secondary);">Bucket: <span id="edit-url-bucket-name" class="font-semibold" style="color: var(--text-primary);"></span></p>
+      <div>
+        <label class="block text-sm font-medium mb-1" style="color: var(--text-secondary);">Public URL <span class="font-normal" style="color: var(--text-tertiary);">(optional)</span></label>
+        <input id="edit-url-input" type="url" placeholder="https://cdn.example.com"
+          class="w-full px-3 py-2 border rounded-lg focus:ring-2 focus:ring-blue-500 outline-none text-sm"
+          style="background-color: var(--bg-secondary); border-color: var(--border-color); color: var(--text-primary);">
+        <p class="text-xs mt-1" style="color: var(--text-tertiary);">Used as base URL for file links. Leave empty to use presigned URLs.</p>
+      </div>
+      <div class="flex gap-3 pt-1">
+        <button type="button" onclick="closeEditUrlModal()" class="flex-1 px-4 py-2 border rounded-lg text-sm transition-colors" style="border-color: var(--border-color); color: var(--text-secondary); background-color: var(--bg-secondary);">Cancel</button>
+        <button type="button" onclick="submitEditUrl()" id="edit-url-btn" class="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg text-sm font-medium transition-colors">Save</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <script src="/js/bucket-selector.js"></script>
 </body>
 </html>

--- a/public/bucket-selector.html
+++ b/public/bucket-selector.html
@@ -57,7 +57,7 @@
     <form id="create-form" onsubmit="submitCreate(event)" class="p-6 space-y-4">
       <div>
         <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Bucket Name</label>
-        <input id="f-name" type="text" placeholder="my-bucket" required pattern="[a-z0-9][a-z0-9\-]{1,61}[a-z0-9]"
+        <input id="f-name" type="text" placeholder="my-bucket" required
           class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
         <p class="text-xs text-gray-400 mt-1">Lowercase letters, numbers, hyphens (3–63 chars)</p>
       </div>

--- a/public/bucket-selector.html
+++ b/public/bucket-selector.html
@@ -22,6 +22,12 @@
       color: #f9fafb !important;
       border-color: #4b5563 !important;
     }
+    /* Fix text visibility on bucket selector page */
+    body { color: #111827; }
+    [data-theme="dark"] body { color: #f9fafb; }
+    .bucket-card-name { color: #111827 !important; }
+    [data-theme="dark"] .bucket-card-name { color: #f9fafb !important; }
+    .bucket-card-sub { color: #6b7280 !important; }
   </style>
 </head>
 <body class="bg-gray-50 dark:bg-gray-900 min-h-screen flex flex-col items-center justify-center p-4">
@@ -34,8 +40,8 @@
     <div class="inline-flex items-center justify-center w-16 h-16 bg-blue-100 dark:bg-blue-900 rounded-2xl mb-4">
       <i class="fas fa-database text-blue-600 dark:text-blue-400 text-2xl"></i>
     </div>
-    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Select Bucket</h1>
-    <p class="text-gray-500 dark:text-gray-400 mt-1">Choose a bucket to manage or create a new one</p>
+    <h1 class="text-2xl font-bold" style="color:#111827">Select Bucket</h1>
+    <p class="mt-1" style="color:#6b7280">Choose a bucket to manage or create a new one</p>
   </div>
 
   <!-- Bucket List -->

--- a/public/bucket-selector.html
+++ b/public/bucket-selector.html
@@ -1,0 +1,103 @@
+<!DOCTYPE html>
+<html lang="id">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Select Bucket — R2 Panel</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="/css/main.css">
+  <script src="/js/theme.js"></script>
+</head>
+<body class="bg-gray-50 dark:bg-gray-900 min-h-screen flex flex-col items-center justify-center p-4">
+
+<div id="toast-container" class="fixed bottom-5 right-5 z-[100] flex flex-col gap-3"></div>
+
+<div class="w-full max-w-2xl">
+  <!-- Header -->
+  <div class="text-center mb-8">
+    <div class="inline-flex items-center justify-center w-16 h-16 bg-blue-100 dark:bg-blue-900 rounded-2xl mb-4">
+      <i class="fas fa-database text-blue-600 dark:text-blue-400 text-2xl"></i>
+    </div>
+    <h1 class="text-2xl font-bold text-gray-900 dark:text-white">Select Bucket</h1>
+    <p class="text-gray-500 dark:text-gray-400 mt-1">Choose a bucket to manage or create a new one</p>
+  </div>
+
+  <!-- Bucket List -->
+  <div id="bucket-list" class="space-y-3 mb-6">
+    <div class="flex items-center justify-center py-8">
+      <i class="fas fa-spinner fa-spin text-gray-400 text-2xl"></i>
+    </div>
+  </div>
+
+  <!-- Actions -->
+  <div class="flex gap-3">
+    <button onclick="openCreateModal()" class="flex-1 flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 hover:bg-blue-700 text-white rounded-xl font-medium transition-colors">
+      <i class="fas fa-plus"></i> Add Bucket
+    </button>
+    <button onclick="logout()" class="px-4 py-3 text-gray-500 dark:text-gray-400 hover:text-red-500 border border-gray-200 dark:border-gray-700 rounded-xl transition-colors">
+      <i class="fas fa-sign-out-alt"></i>
+    </button>
+  </div>
+</div>
+
+<!-- Create Bucket Modal -->
+<div id="create-modal" class="fixed inset-0 bg-black/50 z-50 hidden flex items-center justify-center p-4">
+  <div class="bg-white dark:bg-gray-800 rounded-2xl shadow-xl w-full max-w-lg">
+    <div class="flex items-center justify-between p-6 border-b border-gray-100 dark:border-gray-700">
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Add Bucket</h2>
+      <button onclick="closeCreateModal()" class="text-gray-400 hover:text-gray-600 dark:hover:text-gray-200">
+        <i class="fas fa-times"></i>
+      </button>
+    </div>
+    <form id="create-form" onsubmit="submitCreate(event)" class="p-6 space-y-4">
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Bucket Name</label>
+        <input id="f-name" type="text" placeholder="my-bucket" required pattern="[a-z0-9][a-z0-9\-]{1,61}[a-z0-9]"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+        <p class="text-xs text-gray-400 mt-1">Lowercase letters, numbers, hyphens (3–63 chars)</p>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">R2 Endpoint</label>
+        <input id="f-endpoint" type="url" placeholder="https://account-id.r2.cloudflarestorage.com" required
+          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+      </div>
+      <div class="grid grid-cols-2 gap-3">
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Access Key ID</label>
+          <input id="f-access-key" type="text" placeholder="Access Key ID" required
+            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+        </div>
+        <div>
+          <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Secret Access Key</label>
+          <input id="f-secret-key" type="password" placeholder="Secret Access Key" required
+            class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+        </div>
+      </div>
+      <div>
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">Public URL <span class="text-gray-400 font-normal">(optional)</span></label>
+        <input id="f-public-url" type="url" placeholder="https://pub-xxx.r2.dev"
+          class="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-lg bg-white dark:bg-gray-700 text-gray-900 dark:text-white focus:ring-2 focus:ring-blue-500 outline-none">
+      </div>
+      <div class="flex items-center gap-2">
+        <input id="f-create-cf" type="checkbox" class="rounded">
+        <label for="f-create-cf" class="text-sm text-gray-700 dark:text-gray-300">
+          Also create bucket on Cloudflare R2 <span class="text-gray-400">(requires CF_ACCOUNT_ID + CF_API_TOKEN in env)</span>
+        </label>
+      </div>
+      <div class="flex gap-3 pt-2">
+        <button type="button" onclick="closeCreateModal()" class="flex-1 px-4 py-2 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-300 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors">
+          Cancel
+        </button>
+        <button type="submit" id="create-btn" class="flex-1 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg font-medium transition-colors">
+          <span id="create-btn-text">Add Bucket</span>
+        </button>
+      </div>
+    </form>
+  </div>
+</div>
+
+<script src="/js/bucket-selector.js"></script>
+</body>
+</html>

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -79,43 +79,45 @@ body {
     background-color: var(--bg-tertiary);
 }
 
-/* Dark mode overrides for common elements */
-.bg-white {
+/* Dark mode overrides for common elements — only apply in dark mode */
+[data-theme="dark"] .bg-white {
     background-color: var(--bg-primary) !important;
 }
 
-.bg-gray-50 {
+[data-theme="dark"] .bg-gray-50 {
     background-color: var(--bg-secondary) !important;
 }
 
-.bg-gray-100 {
+[data-theme="dark"] .bg-gray-100 {
     background-color: var(--bg-tertiary) !important;
 }
 
-.text-gray-800 {
+[data-theme="dark"] .text-gray-800 {
     color: var(--text-primary) !important;
 }
 
-.text-gray-600 {
+[data-theme="dark"] .text-gray-600 {
     color: var(--text-secondary) !important;
 }
 
-.text-gray-500 {
+[data-theme="dark"] .text-gray-500 {
     color: var(--text-tertiary) !important;
 }
 
-.border-gray-300 {
+[data-theme="dark"] .border-gray-300 {
     border-color: var(--border-color) !important;
 }
 
-.border-gray-200 {
+[data-theme="dark"] .border-gray-200 {
     border-color: var(--border-color) !important;
 }
 
-/* Toast Notifications */
 .toast {
     animation: slide-in 0.3s ease-out, fade-out 0.5s ease-in forwards;
     animation-delay: 0s, 3.5s;
+}
+
+[data-theme="dark"] .toast {
     background-color: var(--bg-primary);
     border: 1px solid var(--border-color);
     color: var(--text-primary);
@@ -186,7 +188,7 @@ body {
     transition: opacity 0.3s ease;
 }
 
-#confirm-modal .bg-white {
+[data-theme="dark"] #confirm-modal .bg-white {
     background-color: var(--bg-primary) !important;
 }
 
@@ -281,14 +283,18 @@ body {
     background-color: var(--bg-tertiary);
 }
 
-/* Input and Form Elements */
-input, textarea, select {
+/* Input and Form Elements — dark mode only */
+[data-theme="dark"] input,
+[data-theme="dark"] textarea,
+[data-theme="dark"] select {
     background-color: var(--bg-primary);
     border-color: var(--border-color);
     color: var(--text-primary);
 }
 
-input:focus, textarea:focus, select:focus {
+[data-theme="dark"] input:focus,
+[data-theme="dark"] textarea:focus,
+[data-theme="dark"] select:focus {
     border-color: var(--primary-color);
     background-color: var(--bg-primary);
 }

--- a/public/css/main.css
+++ b/public/css/main.css
@@ -299,6 +299,22 @@ body {
     background-color: var(--bg-primary);
 }
 
+/* Light mode input fixes */
+input,
+textarea,
+select {
+    background-color: var(--bg-primary);
+    border-color: var(--border-color);
+    color: var(--text-primary);
+}
+
+input:focus,
+textarea:focus,
+select:focus {
+    border-color: var(--primary-color);
+    background-color: var(--bg-primary);
+}
+
 /* WebP Converter Specific Styles */
 .quality-slider {
     width: 100%;

--- a/public/index.html
+++ b/public/index.html
@@ -210,7 +210,7 @@
                     <button id="logoutBtn" class="p-2.5 rounded-lg hover:bg-red-100 hover:text-red-700 transition-colors theme-toggle" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Keluar">
                         <i class="fas fa-sign-out-alt"></i>
                     </button>
-                    <button id="theme-toggle" onclick="toggleTheme()" class="p-2.5 rounded-lg transition-colors theme-toggle" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Toggle theme">
+                    <button id="theme-toggle" class="p-2.5 rounded-lg transition-colors theme-toggle" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Toggle theme">
                         <i class="fas fa-moon"></i>
                     </button>
                 </div>

--- a/public/index.html
+++ b/public/index.html
@@ -218,22 +218,24 @@
         </header>
 
         <div class="rounded-xl shadow-md p-4 mb-6 sticky top-4 z-20" style="background-color: var(--bg-primary);">
-            <div class="flex flex-col md:flex-row gap-4 justify-between">
-                <div class="flex items-center flex-wrap gap-2">
-                    <button data-filter="all" class="filter-btn active text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1">Semua <span id="countAll" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--primary-color); color: white;">0</span></button>
-                    <button data-filter="image" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-image mr-1 sm:mr-2"></i>Gambar <span id="countImage" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
-                    <button data-filter="doc" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-file-alt mr-1 sm:mr-2"></i>Dokumen <span id="countDoc" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
-                    <button data-filter="audio" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-music mr-1 sm:mr-2"></i>Audio <span id="countAudio" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
-                    <button data-filter="video" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-video mr-1 sm:mr-2"></i>Video <span id="countVideo" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
-                    <button data-filter="archive" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-file-archive mr-1 sm:mr-2"></i>Arsip <span id="countArchive" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
+            <div class="flex items-center gap-3">
+                <!-- Filter buttons: scrollable, no wrap -->
+                <div class="flex items-center gap-2 overflow-x-auto flex-1 min-w-0 pb-0.5" style="scrollbar-width: none;">
+                    <button data-filter="all" class="filter-btn active flex-shrink-0 text-xs px-3 py-1.5 rounded-full transition-colors flex items-center gap-1">Semua <span id="countAll" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--primary-color); color: white;">0</span></button>
+                    <button data-filter="image" class="filter-btn flex-shrink-0 text-xs px-3 py-1.5 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-image mr-1"></i>Gambar <span id="countImage" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
+                    <button data-filter="doc" class="filter-btn flex-shrink-0 text-xs px-3 py-1.5 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-file-alt mr-1"></i>Dokumen <span id="countDoc" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
+                    <button data-filter="audio" class="filter-btn flex-shrink-0 text-xs px-3 py-1.5 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-music mr-1"></i>Audio <span id="countAudio" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
+                    <button data-filter="video" class="filter-btn flex-shrink-0 text-xs px-3 py-1.5 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-video mr-1"></i>Video <span id="countVideo" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
+                    <button data-filter="archive" class="filter-btn flex-shrink-0 text-xs px-3 py-1.5 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-file-archive mr-1"></i>Arsip <span id="countArchive" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
                 </div>
-                <div class="flex gap-2 min-w-0">
-                    <div class="relative flex-1 min-w-0">
-                        <input type="text" id="searchInput" placeholder="Cari file..." class="w-full py-2 pl-9 pr-4 border rounded-full focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
-                        <i class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-sm" style="color: var(--text-tertiary);"></i>
+                <!-- Search + Refresh: fixed width, no shrink -->
+                <div class="flex items-center gap-2 flex-shrink-0">
+                    <div class="relative">
+                        <input type="text" id="searchInput" placeholder="Cari file..." class="py-1.5 pl-8 pr-3 border rounded-full text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" style="width: 180px; background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
+                        <i class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-xs" style="color: var(--text-tertiary);"></i>
                     </div>
-                    <button id="refreshBtn" class="p-2 w-10 h-10 flex items-center justify-center rounded-full border" style="background-color: var(--bg-primary); border-color: var(--border-color);" title="Muat Ulang">
-                        <i class="fas fa-sync-alt" style="color: var(--primary-color);"></i>
+                    <button id="refreshBtn" class="p-2 w-8 h-8 flex-shrink-0 flex items-center justify-center rounded-full border" style="background-color: var(--bg-primary); border-color: var(--border-color);" title="Muat Ulang">
+                        <i class="fas fa-sync-alt text-xs" style="color: var(--primary-color);"></i>
                     </button>
                 </div>
             </div>

--- a/public/index.html
+++ b/public/index.html
@@ -164,7 +164,10 @@
                         <h1 class="text-xl sm:text-2xl font-bold text-gray-800">
                             R2 Cloudflare File Manager
                         </h1>
-                        <p class="text-gray-500 text-sm hidden sm:block">Seret dan lepas untuk mengelola file Anda.</p>
+                        <p class="text-gray-500 text-sm hidden sm:block">
+                          Bucket: <span id="active-bucket-name" class="font-semibold text-indigo-600">—</span>
+                          <a href="/bucket-selector" class="ml-2 text-xs text-gray-400 hover:text-indigo-500"><i class="fas fa-exchange-alt"></i> switch</a>
+                        </p>
                     </div>
                 </div>
                 

--- a/public/index.html
+++ b/public/index.html
@@ -227,10 +227,10 @@
                     <button data-filter="video" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-video mr-1 sm:mr-2"></i>Video <span id="countVideo" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
                     <button data-filter="archive" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-file-archive mr-1 sm:mr-2"></i>Arsip <span id="countArchive" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
                 </div>
-                <div class="flex gap-2">
-                    <div class="relative flex-grow">
-                        <input type="text" id="searchInput" placeholder="Cari file..." class="w-full py-2 pl-10 pr-4 border rounded-full focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
-                        <i class="fas fa-search absolute left-4 top-1/2 -translate-y-1/2" style="color: var(--text-tertiary);"></i>
+                <div class="flex gap-2 min-w-0">
+                    <div class="relative flex-1 min-w-0">
+                        <input type="text" id="searchInput" placeholder="Cari file..." class="w-full py-2 pl-9 pr-4 border rounded-full focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
+                        <i class="fas fa-search absolute left-3 top-1/2 -translate-y-1/2 text-sm" style="color: var(--text-tertiary);"></i>
                     </div>
                     <button id="refreshBtn" class="p-2 w-10 h-10 flex items-center justify-center rounded-full border" style="background-color: var(--bg-primary); border-color: var(--border-color);" title="Muat Ulang">
                         <i class="fas fa-sync-alt" style="color: var(--primary-color);"></i>

--- a/public/index.html
+++ b/public/index.html
@@ -13,7 +13,7 @@
     <link rel="stylesheet" href="/css/main.css">
     <script src="/js/theme.js"></script>
 </head>
-<body class="bg-gray-50 min-h-screen">
+<body class="min-h-screen" style="background-color: var(--bg-secondary);">
 
     <div id="toast-container" class="fixed bottom-5 right-5 z-[100] flex flex-col gap-3"></div>
 
@@ -109,32 +109,32 @@
 
     <!-- Convert Options Modal -->
     <div id="convertModal" class="fixed inset-0 z-[95] flex items-center justify-center p-4 hidden opacity-0">
-        <div class="bg-white rounded-lg shadow-xl p-6 w-full max-w-md">
-            <h3 class="text-lg font-bold text-gray-800 mb-4">Convert to WebP</h3>
-            <p class="text-gray-600 mb-4">Convert <span id="convertCount" class="font-bold text-indigo-600">0</span> selected image(s) to WebP format.</p>
+        <div class="rounded-lg shadow-xl p-6 w-full max-w-md" style="background-color: var(--bg-primary);">
+            <h3 class="text-lg font-bold mb-4" style="color: var(--text-primary);">Convert to WebP</h3>
+            <p class="mb-4" style="color: var(--text-secondary);">Convert <span id="convertCount" class="font-bold" style="color: var(--primary-color);">0</span> selected image(s) to WebP format.</p>
             
             <div class="space-y-4 mb-6">
                 <div>
-                    <label for="convertQuality" class="block text-sm font-medium text-gray-700 mb-2">
-                        Quality: <span id="convertQualityValue" class="font-bold text-indigo-600">80</span>%
+                    <label for="convertQuality" class="block text-sm font-medium mb-2" style="color: var(--text-secondary);">
+                        Quality: <span id="convertQualityValue" class="font-bold" style="color: var(--primary-color);">80</span>%
                     </label>
                     <input type="range" id="convertQuality" class="w-full" min="10" max="100" value="80">
-                    <div class="flex justify-between text-xs text-gray-500 mt-1">
+                    <div class="flex justify-between text-xs mt-1" style="color: var(--text-tertiary);">
                         <span>Smaller (10%)</span>
                         <span>Best (100%)</span>
                     </div>
                 </div>
                 
-                <div class="flex items-center p-3 bg-yellow-50 rounded-lg border border-yellow-100">
+                <div class="flex items-center p-3 rounded-lg border" style="background-color: var(--warning-bg); border-color: var(--warning-border);">
                     <input type="checkbox" id="deleteOriginalCheckbox" class="h-4 w-4 text-indigo-600 focus:ring-indigo-500 border-gray-300 rounded mr-3">
-                    <label for="deleteOriginalCheckbox" class="text-sm text-gray-700">
+                    <label for="deleteOriginalCheckbox" class="text-sm" style="color: var(--warning-text);">
                         Delete original files after conversion
                     </label>
                 </div>
             </div>
             
             <div class="flex justify-end gap-3">
-                <button id="convertCancelBtn" class="px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300">Cancel</button>
+                <button id="convertCancelBtn" class="px-4 py-2 rounded-lg transition-colors" style="background-color: var(--bg-secondary); color: var(--text-secondary);">Cancel</button>
                 <button id="convertConfirmBtn" class="px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700">
                     <i class="fas fa-magic mr-2"></i>Convert
                 </button>
@@ -143,35 +143,35 @@
     </div>
 
     <div id="confirm-modal" class="fixed inset-0 z-[95] flex items-center justify-center p-4 hidden opacity-0">
-        <div class="bg-white rounded-lg shadow-xl p-6 w-full max-w-sm">
-            <h3 id="confirm-title" class="text-lg font-bold text-gray-800">Anda Yakin?</h3>
-            <p id="confirm-message" class="text-gray-600 mt-2">Aksi ini tidak dapat dibatalkan.</p>
+        <div class="rounded-lg shadow-xl p-6 w-full max-w-sm" style="background-color: var(--bg-primary);">
+            <h3 id="confirm-title" class="text-lg font-bold" style="color: var(--text-primary);">Anda Yakin?</h3>
+            <p id="confirm-message" class="mt-2" style="color: var(--text-secondary);">Aksi ini tidak dapat dibatalkan.</p>
             <div class="mt-6 flex justify-end gap-3">
-                <button id="confirm-cancel-btn" class="px-4 py-2 bg-gray-200 text-gray-800 rounded-lg hover:bg-gray-300">Batal</button>
+                <button id="confirm-cancel-btn" class="px-4 py-2 rounded-lg transition-colors" style="background-color: var(--bg-secondary); color: var(--text-secondary);">Batal</button>
                 <button id="confirm-ok-btn" class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700">Hapus</button>
             </div>
         </div>
     </div>
 
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 max-w-7xl">
-        <header class="bg-white shadow-md rounded-xl p-4 sm:p-6 mb-8">
+        <header class="shadow-md rounded-xl p-4 sm:p-6 mb-8" style="background-color: var(--bg-primary);">
             <div class="flex flex-wrap justify-between items-center gap-y-4">
                 <div class="flex items-center">
                     <span class="text-white bg-indigo-600 rounded-lg p-2 mr-3">
                         <i class="fas fa-cloud"></i>
                     </span>
                     <div>
-                        <h1 class="text-xl sm:text-2xl font-bold text-gray-800">
+                        <h1 class="text-xl sm:text-2xl font-bold" style="color: var(--text-primary);">
                             R2 Cloudflare File Manager
                         </h1>
-                        <p class="text-gray-500 text-sm hidden sm:block">
-                          Bucket: <span id="active-bucket-name" class="font-semibold text-indigo-600">—</span>
-                          <a href="/bucket-selector" class="ml-2 text-xs text-gray-400 hover:text-indigo-500"><i class="fas fa-exchange-alt"></i> switch</a>
+                        <p class="text-sm hidden sm:block" style="color: var(--text-secondary);">
+                          Bucket: <span id="active-bucket-name" class="font-semibold" style="color: var(--primary-color);">—</span>
+                          <a href="/bucket-selector" class="ml-2 text-xs hover:text-indigo-500" style="color: var(--text-tertiary);"><i class="fas fa-exchange-alt"></i> switch</a>
                         </p>
                     </div>
                 </div>
                 
-                <div id="dropArea" class="w-full sm:w-auto flex items-center justify-end gap-2 border-2 border-dashed border-gray-300 rounded-lg p-2 transition-all hover:border-indigo-500 hover:bg-indigo-50">
+                <div id="dropArea" class="w-full sm:w-auto flex items-center justify-end gap-2 border-2 border-dashed rounded-lg p-2 transition-all" style="border-color: var(--border-color);" onmouseover="this.style.borderColor='var(--primary-color)'; this.style.backgroundColor='var(--bg-tertiary)'" onmouseout="this.style.borderColor='var(--border-color)'; this.style.backgroundColor='transparent'">
                     <input type="file" id="fileInput" class="hidden" multiple>
                     <button id="browseButton" class="bg-indigo-600 text-white px-4 py-2 rounded-lg hover:bg-indigo-700 transition-colors text-sm font-semibold flex-grow sm:flex-grow-0 flex items-center justify-center gap-2">
                         <i class="fas fa-upload"></i>
@@ -180,7 +180,7 @@
                     </button>
                     
                     <!-- Bulk Actions - Auto show when files selected -->
-                    <div id="bulkActions" class="hidden flex items-center gap-2 border-l-2 border-gray-300 pl-2">
+                    <div id="bulkActions" class="hidden flex items-center gap-2 pl-2" style="border-left: 2px solid var(--border-color);">
                         <button id="selectAllToggleBtn" class="bg-gray-600 text-white px-3 py-2 rounded-lg hover:bg-gray-700 transition-colors text-sm font-semibold flex items-center gap-2" title="Select All">
                             <i class="fas fa-check-double"></i>
                             <span class="hidden md:inline">All</span>
@@ -198,7 +198,7 @@
                         </button>
                     </div>
                     
-                    <a href="/api-docs" class="bg-gray-200 text-gray-700 p-2.5 rounded-lg hover:bg-gray-300 transition-colors" title="Dokumentasi API">
+                    <a href="/api-docs" class="p-2.5 rounded-lg transition-colors" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Dokumentasi API">
                         <i class="fas fa-code"></i>
                     </a>
                     <a href="/webp-converter" class="bg-green-200 text-green-700 p-2.5 rounded-lg hover:bg-green-300 transition-colors" title="WebP Converter">
@@ -207,14 +207,14 @@
                     <a href="/stats" class="bg-blue-200 text-blue-700 p-2.5 rounded-lg hover:bg-blue-300 transition-colors" title="Storage Statistics">
                         <i class="fas fa-chart-bar"></i>
                     </a>
-                    <button id="logoutBtn" class="bg-gray-200 text-gray-700 p-2.5 rounded-lg hover:bg-red-200 hover:text-red-700 transition-colors" title="Keluar">
+                    <button id="logoutBtn" class="p-2.5 rounded-lg hover:bg-red-200 hover:text-red-700 transition-colors" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Keluar">
                         <i class="fas fa-sign-out-alt"></i>
                     </button>
                 </div>
             </div>
         </header>
 
-        <div class="bg-white rounded-xl shadow-md p-4 mb-6 sticky top-4 z-20">
+        <div class="rounded-xl shadow-md p-4 mb-6 sticky top-4 z-20" style="background-color: var(--bg-primary);">
             <div class="flex flex-col md:flex-row gap-4 justify-between">
                 <div class="flex items-center flex-wrap gap-2">
                     <button data-filter="all" class="filter-btn active text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors flex items-center gap-1">Semua <span id="countAll" class="ml-1 bg-gray-400 text-white rounded-full px-2 text-xs font-bold">0</span></button>
@@ -226,40 +226,40 @@
                 </div>
                 <div class="flex gap-2">
                     <div class="relative flex-grow">
-                        <input type="text" id="searchInput" placeholder="Cari file..." class="w-full py-2 pl-10 pr-4 border border-gray-300 rounded-full focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500">
-                        <i class="fas fa-search absolute left-4 top-1/2 -translate-y-1/2 text-gray-400"></i>
+                        <input type="text" id="searchInput" placeholder="Cari file..." class="w-full py-2 pl-10 pr-4 border rounded-full focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500" style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);">
+                        <i class="fas fa-search absolute left-4 top-1/2 -translate-y-1/2" style="color: var(--text-tertiary);"></i>
                     </div>
-                    <button id="refreshBtn" class="p-2 w-10 h-10 flex items-center justify-center rounded-full bg-white border border-gray-300 hover:bg-gray-100" title="Muat Ulang">
-                        <i class="fas fa-sync-alt text-indigo-600"></i>
+                    <button id="refreshBtn" class="p-2 w-10 h-10 flex items-center justify-center rounded-full border" style="background-color: var(--bg-primary); border-color: var(--border-color);" title="Muat Ulang">
+                        <i class="fas fa-sync-alt" style="color: var(--primary-color);"></i>
                     </button>
                 </div>
             </div>
         </div>
 
         <div id="filesGrid" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 gap-4 lg:gap-6">
-            <div id="loading-indicator" class="col-span-full text-center py-16 text-gray-500">
+            <div id="loading-indicator" class="col-span-full text-center py-16" style="color: var(--text-secondary);">
                 <i class="fas fa-spinner fa-spin text-3xl mb-4"></i>
                 <p>Memuat file, mohon tunggu...</p>
             </div>
         </div>
-        <div id="empty-state" class="col-span-full text-center py-16 text-gray-500 hidden">
-            <i class="fas fa-folder-open text-5xl mb-4 text-gray-300"></i>
+        <div id="empty-state" class="col-span-full text-center py-16 hidden" style="color: var(--text-secondary);">
+            <i class="fas fa-folder-open text-5xl mb-4" style="color: var(--text-tertiary);"></i>
             <p class="text-xl font-semibold">Tidak ada file ditemukan</p>
             <p>Coba unggah beberapa file atau ubah filter Anda.</p>
         </div>
 
         <div id="pagination-controls" class="text-center mt-8">
-            <button id="loadMoreBtn" class="bg-white text-indigo-600 font-semibold px-6 py-3 rounded-full shadow-md hover:bg-gray-100 transition-colors disabled:opacity-50 disabled:cursor-not-allowed hidden">
+            <button id="loadMoreBtn" class="font-semibold px-6 py-3 rounded-full shadow-md transition-colors disabled:opacity-50 disabled:cursor-not-allowed hidden" style="background-color: var(--bg-primary); color: var(--primary-color);">
                 Muat Lebih Banyak
             </button>
         </div>
     </div>
 
-    <div id="share-popover" class="hidden absolute z-50 bg-white rounded-lg shadow-xl border border-gray-200 p-2 flex flex-col gap-1 min-w-[220px] max-w-[280px] opacity-0 scale-95">
-        <button id="copy-cdn-btn" class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md flex items-center gap-2">
+    <div id="share-popover" class="hidden absolute z-50 rounded-lg shadow-xl border p-2 flex flex-col gap-1 min-w-[220px] max-w-[280px] opacity-0 scale-95" style="background-color: var(--bg-primary); border-color: var(--border-color);">
+        <button id="copy-cdn-btn" class="w-full text-left px-3 py-2 text-sm rounded-md flex items-center gap-2 transition-colors" style="color: var(--text-primary);" onmouseover="this.style.backgroundColor='var(--hover-bg)'" onmouseout="this.style.backgroundColor='transparent'">
             <i class="fas fa-link fa-fw"></i> <span class="truncate">Salin URL Publik</span>
         </button>
-        <button id="copy-presigned-btn" class="w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-gray-100 rounded-md flex items-center gap-2">
+        <button id="copy-presigned-btn" class="w-full text-left px-3 py-2 text-sm rounded-md flex items-center gap-2 transition-colors" style="color: var(--text-primary);" onmouseover="this.style.backgroundColor='var(--hover-bg)'" onmouseout="this.style.backgroundColor='transparent'">
             <i class="fas fa-user-clock fa-fw"></i> <span class="truncate">Salin URL Sementara</span>
         </button>
     </div>

--- a/public/index.html
+++ b/public/index.html
@@ -198,17 +198,20 @@
                         </button>
                     </div>
                     
-                    <a href="/api-docs" class="p-2.5 rounded-lg transition-colors" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Dokumentasi API">
+                    <a href="/api-docs" class="p-2.5 rounded-lg transition-colors theme-toggle" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Dokumentasi API">
                         <i class="fas fa-code"></i>
                     </a>
-                    <a href="/webp-converter" class="bg-green-200 text-green-700 p-2.5 rounded-lg hover:bg-green-300 transition-colors" title="WebP Converter">
+                    <a href="/webp-converter" class="p-2.5 rounded-lg transition-colors theme-toggle" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="WebP Converter">
                         <i class="fas fa-image"></i>
                     </a>
-                    <a href="/stats" class="bg-blue-200 text-blue-700 p-2.5 rounded-lg hover:bg-blue-300 transition-colors" title="Storage Statistics">
+                    <a href="/stats" class="p-2.5 rounded-lg transition-colors theme-toggle" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Storage Statistics">
                         <i class="fas fa-chart-bar"></i>
                     </a>
-                    <button id="logoutBtn" class="p-2.5 rounded-lg hover:bg-red-200 hover:text-red-700 transition-colors" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Keluar">
+                    <button id="logoutBtn" class="p-2.5 rounded-lg hover:bg-red-100 hover:text-red-700 transition-colors theme-toggle" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Keluar">
                         <i class="fas fa-sign-out-alt"></i>
+                    </button>
+                    <button id="theme-toggle" onclick="toggleTheme()" class="p-2.5 rounded-lg transition-colors theme-toggle" style="background-color: var(--bg-tertiary); color: var(--text-secondary);" title="Toggle theme">
+                        <i class="fas fa-moon"></i>
                     </button>
                 </div>
             </div>
@@ -217,12 +220,12 @@
         <div class="rounded-xl shadow-md p-4 mb-6 sticky top-4 z-20" style="background-color: var(--bg-primary);">
             <div class="flex flex-col md:flex-row gap-4 justify-between">
                 <div class="flex items-center flex-wrap gap-2">
-                    <button data-filter="all" class="filter-btn active text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors flex items-center gap-1">Semua <span id="countAll" class="ml-1 bg-gray-400 text-white rounded-full px-2 text-xs font-bold">0</span></button>
-                    <button data-filter="image" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors flex items-center gap-1"><i class="fas fa-image mr-1 sm:mr-2"></i>Gambar <span id="countImage" class="ml-1 bg-gray-300 text-gray-700 rounded-full px-2 text-xs font-bold">0</span></button>
-                    <button data-filter="doc" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors flex items-center gap-1"><i class="fas fa-file-alt mr-1 sm:mr-2"></i>Dokumen <span id="countDoc" class="ml-1 bg-gray-300 text-gray-700 rounded-full px-2 text-xs font-bold">0</span></button>
-                    <button data-filter="audio" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors flex items-center gap-1"><i class="fas fa-music mr-1 sm:mr-2"></i>Audio <span id="countAudio" class="ml-1 bg-gray-300 text-gray-700 rounded-full px-2 text-xs font-bold">0</span></button>
-                    <button data-filter="video" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors flex items-center gap-1"><i class="fas fa-video mr-1 sm:mr-2"></i>Video <span id="countVideo" class="ml-1 bg-gray-300 text-gray-700 rounded-full px-2 text-xs font-bold">0</span></button>
-                    <button data-filter="archive" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full bg-gray-200 text-gray-700 hover:bg-gray-300 transition-colors flex items-center gap-1"><i class="fas fa-file-archive mr-1 sm:mr-2"></i>Arsip <span id="countArchive" class="ml-1 bg-gray-300 text-gray-700 rounded-full px-2 text-xs font-bold">0</span></button>
+                    <button data-filter="all" class="filter-btn active text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1">Semua <span id="countAll" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--primary-color); color: white;">0</span></button>
+                    <button data-filter="image" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-image mr-1 sm:mr-2"></i>Gambar <span id="countImage" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
+                    <button data-filter="doc" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-file-alt mr-1 sm:mr-2"></i>Dokumen <span id="countDoc" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
+                    <button data-filter="audio" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-music mr-1 sm:mr-2"></i>Audio <span id="countAudio" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
+                    <button data-filter="video" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-video mr-1 sm:mr-2"></i>Video <span id="countVideo" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
+                    <button data-filter="archive" class="filter-btn text-xs sm:text-sm px-3 py-1.5 sm:px-4 sm:py-2 rounded-full transition-colors flex items-center gap-1"><i class="fas fa-file-archive mr-1 sm:mr-2"></i>Arsip <span id="countArchive" class="ml-1 rounded-full px-2 text-xs font-bold" style="background-color: var(--bg-tertiary); color: var(--text-secondary);">0</span></button>
                 </div>
                 <div class="flex gap-2">
                     <div class="relative flex-grow">

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -58,8 +58,8 @@ async function loadBuckets() {
           <button onclick="event.stopPropagation(); copyBucketId('${b.id}', '${escHtml(b.name)}')" class="p-1.5 hover:text-indigo-500 transition-colors" style="color: var(--text-tertiary);" title="Copy Bucket ID">
             <i class="fas fa-fingerprint text-sm"></i>
           </button>
-          <button onclick="event.stopPropagation(); syncBucket('${b.id}', '${escHtml(b.name)}')" class="p-1.5 hover:text-blue-500 transition-colors" style="color: var(--text-tertiary);" title="Sync public URL from Cloudflare">
-            <i class="fas fa-sync-alt text-sm"></i>
+          <button onclick="event.stopPropagation(); editPublicUrl('${b.id}', '${escHtml(b.name)}', '${escHtml(b.publicUrl || '')}')" class="p-1.5 hover:text-blue-500 transition-colors" style="color: var(--text-tertiary);" title="Set Public URL">
+            <i class="fas fa-link text-sm"></i>
           </button>
           <button onclick="event.stopPropagation(); deleteBucket('${b.id}', '${escHtml(b.name)}')" class="p-1.5 hover:text-red-500 transition-colors" style="color: var(--text-tertiary);" title="Remove from panel">
             <i class="fas fa-trash text-sm"></i>
@@ -133,7 +133,6 @@ function copyBucketId(id, name) {
   navigator.clipboard.writeText(id).then(() => {
     showToast(`Bucket ID copied: ${name}`, 'success');
   }).catch(() => {
-    // fallback for older browsers
     const el = document.createElement('textarea');
     el.value = id;
     document.body.appendChild(el);
@@ -144,17 +143,18 @@ function copyBucketId(id, name) {
   });
 }
 
-async function syncBucket(id, name) {
-  try {
-    const res = await fetch(`/api/buckets/${id}/sync`, { method: 'POST' });
-    const data = await res.json();
-    if (!res.ok) throw new Error(data.meta?.message || data.error || 'Sync failed');
-    const msg = data.data?.publicUrl ? `Public URL synced: ${data.data.publicUrl}` : 'No public domain found on Cloudflare';
-    showToast(msg, data.data?.publicUrl ? 'success' : 'info');
+function editPublicUrl(id, name, currentUrl) {
+  const url = prompt(`Public URL for "${name}":\n(e.g. https://cdn.example.com — leave empty to clear)`, currentUrl || '');
+  if (url === null) return; // cancelled
+  fetch(`/api/buckets/${id}/sync`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ publicUrl: url.trim() }),
+  }).then(r => r.json()).then(data => {
+    if (data.meta?.code !== 200) throw new Error(data.meta?.message || 'Failed');
+    showToast(url.trim() ? `Public URL set: ${url.trim()}` : 'Public URL cleared', 'success');
     loadBuckets();
-  } catch (err) {
-    showToast(err.message, 'error');
-  }
+  }).catch(err => showToast(err.message, 'error'));
 }
 
 async function deleteBucket(id, name) {

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -51,8 +51,8 @@ async function loadBuckets() {
           <i class="fas fa-bucket text-blue-500 dark:text-blue-400"></i>
         </div>
         <div class="flex-1 min-w-0">
-          <p class="font-semibold text-gray-900 dark:text-white truncate">${escHtml(b.name)}</p>
-          <p class="text-xs text-gray-400 truncate">${new Date(b.createdAt).toLocaleDateString('id-ID', {day:'numeric',month:'short',year:'numeric'})}</p>
+          <p class="bucket-card-name font-semibold truncate">${escHtml(b.name)}</p>
+          <p class="bucket-card-sub text-xs truncate">${new Date(b.createdAt).toLocaleDateString('id-ID', {day:'numeric',month:'short',year:'numeric'})}</p>
         </div>
         <div class="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
           <button onclick="event.stopPropagation(); deleteBucket('${b.id}', '${escHtml(b.name)}')" class="p-1.5 text-gray-400 hover:text-red-500 transition-colors" title="Remove from panel">

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -1,9 +1,32 @@
 // Check auth first
+let _panelConfig = { hasSharedCreds: false, hasCfConfig: false };
+
 (async () => {
   const res = await fetch('/auth/status');
   const data = await res.json();
-  if (!data.data?.authenticated) window.location.href = '/login';
+  if (!data.data?.authenticated) { window.location.href = '/login'; return; }
+
+  // Load panel config
+  try {
+    const cfgRes = await fetch('/api/buckets/config');
+    const cfgData = await cfgRes.json();
+    _panelConfig = cfgData.data || _panelConfig;
+    applyPanelConfig();
+  } catch (e) {}
 })();
+
+function applyPanelConfig() {
+  const credFields = document.getElementById('credential-fields');
+  const credHint = document.getElementById('credential-hint');
+  if (!credFields) return;
+  if (_panelConfig.hasSharedCreds) {
+    credFields.classList.add('hidden');
+    if (credHint) credHint.classList.remove('hidden');
+  } else {
+    credFields.classList.remove('hidden');
+    if (credHint) credHint.classList.add('hidden');
+  }
+}
 
 async function loadBuckets() {
   const list = document.getElementById('bucket-list');
@@ -70,12 +93,16 @@ async function submitCreate(e) {
 
   const payload = {
     name: document.getElementById('f-name').value.trim(),
-    endpoint: document.getElementById('f-endpoint').value.trim(),
-    accessKeyId: document.getElementById('f-access-key').value.trim(),
-    secretAccessKey: document.getElementById('f-secret-key').value.trim(),
     publicUrl: document.getElementById('f-public-url').value.trim(),
     createOnCloudflare: document.getElementById('f-create-cf').checked,
   };
+
+  // Only include credentials if shared creds not configured
+  if (!_panelConfig.hasSharedCreds) {
+    payload.endpoint = document.getElementById('f-endpoint').value.trim();
+    payload.accessKeyId = document.getElementById('f-access-key').value.trim();
+    payload.secretAccessKey = document.getElementById('f-secret-key').value.trim();
+  }
 
   try {
     const res = await fetch('/api/buckets', {

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -52,7 +52,7 @@ async function loadBuckets() {
         </div>
         <div class="flex-1 min-w-0">
           <p class="font-semibold text-gray-900 dark:text-white truncate">${escHtml(b.name)}</p>
-          <p class="text-xs text-gray-400 truncate">${escHtml(b.endpoint || '')}</p>
+          <p class="text-xs text-gray-400 truncate">${new Date(b.createdAt).toLocaleDateString('id-ID', {day:'numeric',month:'short',year:'numeric'})}</p>
         </div>
         <div class="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
           <button onclick="event.stopPropagation(); deleteBucket('${b.id}', '${escHtml(b.name)}')" class="p-1.5 text-gray-400 hover:text-red-500 transition-colors" title="Remove from panel">

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -143,18 +143,46 @@ function copyBucketId(id, name) {
   });
 }
 
+let _editUrlBucketId = null;
+
 function editPublicUrl(id, name, currentUrl) {
-  const url = prompt(`Public URL for "${name}":\n(e.g. https://cdn.example.com — leave empty to clear)`, currentUrl || '');
-  if (url === null) return; // cancelled
-  fetch(`/api/buckets/${id}/sync`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ publicUrl: url.trim() }),
-  }).then(r => r.json()).then(data => {
+  _editUrlBucketId = id;
+  document.getElementById('edit-url-bucket-name').textContent = name;
+  document.getElementById('edit-url-input').value = currentUrl || '';
+  document.getElementById('edit-url-modal').classList.remove('hidden');
+  document.getElementById('edit-url-modal').classList.add('flex');
+  setTimeout(() => document.getElementById('edit-url-input').focus(), 50);
+}
+
+function closeEditUrlModal() {
+  document.getElementById('edit-url-modal').classList.add('hidden');
+  document.getElementById('edit-url-modal').classList.remove('flex');
+  _editUrlBucketId = null;
+}
+
+async function submitEditUrl() {
+  if (!_editUrlBucketId) return;
+  const publicUrl = document.getElementById('edit-url-input').value.trim();
+  const btn = document.getElementById('edit-url-btn');
+  btn.disabled = true;
+  btn.textContent = 'Saving...';
+  try {
+    const res = await fetch(`/api/buckets/${_editUrlBucketId}/sync`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ publicUrl }),
+    });
+    const data = await res.json();
     if (data.meta?.code !== 200) throw new Error(data.meta?.message || 'Failed');
-    showToast(url.trim() ? `Public URL set: ${url.trim()}` : 'Public URL cleared', 'success');
+    showToast(publicUrl ? `Public URL saved` : 'Public URL cleared', 'success');
+    closeEditUrlModal();
     loadBuckets();
-  }).catch(err => showToast(err.message, 'error'));
+  } catch (err) {
+    showToast(err.message, 'error');
+  } finally {
+    btn.disabled = false;
+    btn.textContent = 'Save';
+  }
 }
 
 async function deleteBucket(id, name) {

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -144,7 +144,17 @@ async function loadCfBuckets() {
     const res = await fetch('/api/buckets/cf-list');
     const data = await res.json();
     if (!res.ok) throw new Error(data.error || 'Failed to fetch from Cloudflare');
-    const buckets = data.data || [];
+    const { buckets = [], hasSharedCreds = false } = data.data || {};
+
+    // Show hint based on shared creds availability
+    const hint = document.getElementById('import-hint');
+    if (hint) {
+      hint.innerHTML = hasSharedCreds
+        ? '<i class="fas fa-bolt mr-1 text-green-400"></i> Shared credentials detected — click any bucket to import instantly.'
+        : '<i class="fas fa-info-circle mr-1 text-blue-400"></i> No shared credentials. You\'ll need to enter Access Key + Secret Key per bucket.';
+      hint.className = `text-sm mb-4 ${hasSharedCreds ? 'text-green-600 dark:text-green-400' : 'text-gray-500 dark:text-gray-400'}`;
+    }
+
     if (buckets.length === 0) {
       list.innerHTML = '<p class="text-center text-gray-400 py-6">No buckets found in your Cloudflare account.</p>';
       return;
@@ -154,7 +164,7 @@ async function loadCfBuckets() {
         b.alreadyAdded
           ? 'border-gray-200 dark:border-gray-700 opacity-50'
           : 'border-gray-200 dark:border-gray-700 hover:border-orange-400 cursor-pointer'
-      }" ${!b.alreadyAdded ? `onclick="selectCfBucket('${escHtml(b.name)}', '${escHtml(b.endpoint)}')"`  : ''}>
+      }" ${!b.alreadyAdded ? `onclick="selectCfBucket('${escHtml(b.name)}', '${escHtml(b.endpoint)}', ${hasSharedCreds})"` : ''}>
         <div class="flex items-center gap-3">
           <i class="fas fa-bucket text-orange-400"></i>
           <div>
@@ -164,7 +174,9 @@ async function loadCfBuckets() {
         </div>
         ${b.alreadyAdded
           ? '<span class="text-xs text-green-500 font-medium"><i class="fas fa-check mr-1"></i>Added</span>'
-          : '<i class="fas fa-chevron-right text-gray-300"></i>'
+          : hasSharedCreds
+            ? '<span class="text-xs text-orange-400"><i class="fas fa-bolt mr-1"></i>1-click</span>'
+            : '<i class="fas fa-chevron-right text-gray-300"></i>'
         }
       </div>
     `).join('');
@@ -173,7 +185,26 @@ async function loadCfBuckets() {
   }
 }
 
-function selectCfBucket(name, endpoint) {
+async function selectCfBucket(name, endpoint, hasSharedCreds) {
+  if (hasSharedCreds) {
+    // 1-click import using shared credentials from env
+    try {
+      const res = await fetch('/api/buckets/cf-import', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || data.message || 'Import failed');
+      showToast(`"${name}" imported successfully`, 'success');
+      closeImportModal();
+      loadBuckets();
+    } catch (err) {
+      showToast(err.message, 'error');
+    }
+    return;
+  }
+  // No shared creds — go to step 2 to fill credentials manually
   document.getElementById('i-name').value = name;
   document.getElementById('i-endpoint').value = endpoint;
   document.getElementById('import-bucket-name-label').textContent = name;

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -55,6 +55,9 @@ async function loadBuckets() {
           <p class="bucket-card-sub text-xs truncate">${new Date(b.createdAt).toLocaleDateString('id-ID', {day:'numeric',month:'short',year:'numeric'})}</p>
         </div>
         <div class="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button onclick="event.stopPropagation(); copyBucketId('${b.id}', '${escHtml(b.name)}')" class="p-1.5 hover:text-indigo-500 transition-colors" style="color: var(--text-tertiary);" title="Copy Bucket ID">
+            <i class="fas fa-fingerprint text-sm"></i>
+          </button>
           <button onclick="event.stopPropagation(); syncBucket('${b.id}', '${escHtml(b.name)}')" class="p-1.5 hover:text-blue-500 transition-colors" style="color: var(--text-tertiary);" title="Sync public URL from Cloudflare">
             <i class="fas fa-sync-alt text-sm"></i>
           </button>
@@ -124,6 +127,21 @@ async function submitCreate(e) {
     btn.disabled = false;
     btnText.textContent = 'Add Bucket';
   }
+}
+
+function copyBucketId(id, name) {
+  navigator.clipboard.writeText(id).then(() => {
+    showToast(`Bucket ID copied: ${name}`, 'success');
+  }).catch(() => {
+    // fallback for older browsers
+    const el = document.createElement('textarea');
+    el.value = id;
+    document.body.appendChild(el);
+    el.select();
+    document.execCommand('copy');
+    document.body.removeChild(el);
+    showToast(`Bucket ID copied: ${name}`, 'success');
+  });
 }
 
 async function syncBucket(id, name) {

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -1,0 +1,137 @@
+// Check auth first
+(async () => {
+  const res = await fetch('/auth/status');
+  const data = await res.json();
+  if (!data.data?.authenticated) window.location.href = '/login';
+})();
+
+async function loadBuckets() {
+  const list = document.getElementById('bucket-list');
+  try {
+    const res = await fetch('/api/buckets');
+    if (res.status === 401) { window.location.href = '/login'; return; }
+    const data = await res.json();
+    const buckets = data.data || [];
+
+    if (buckets.length === 0) {
+      list.innerHTML = `
+        <div class="text-center py-10 text-gray-400 dark:text-gray-500">
+          <i class="fas fa-database text-4xl mb-3 block opacity-30"></i>
+          <p>No buckets yet. Add your first bucket.</p>
+        </div>`;
+      return;
+    }
+
+    list.innerHTML = buckets.map(b => `
+      <div class="group flex items-center gap-4 p-4 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl hover:border-blue-400 dark:hover:border-blue-500 hover:shadow-md transition-all cursor-pointer" onclick="selectBucket('${b.id}', '${escHtml(b.name)}')">
+        <div class="flex-shrink-0 w-10 h-10 bg-blue-50 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
+          <i class="fas fa-bucket text-blue-500 dark:text-blue-400"></i>
+        </div>
+        <div class="flex-1 min-w-0">
+          <p class="font-semibold text-gray-900 dark:text-white truncate">${escHtml(b.name)}</p>
+          <p class="text-xs text-gray-400 truncate">${escHtml(b.endpoint || '')}</p>
+        </div>
+        <div class="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button onclick="event.stopPropagation(); deleteBucket('${b.id}', '${escHtml(b.name)}')" class="p-1.5 text-gray-400 hover:text-red-500 transition-colors" title="Remove from panel">
+            <i class="fas fa-trash text-sm"></i>
+          </button>
+          <i class="fas fa-chevron-right text-gray-300 dark:text-gray-600"></i>
+        </div>
+      </div>
+    `).join('');
+  } catch (err) {
+    list.innerHTML = `<div class="text-center py-8 text-red-400"><i class="fas fa-exclamation-circle mr-2"></i>Failed to load buckets</div>`;
+  }
+}
+
+function selectBucket(id, name) {
+  sessionStorage.setItem('activeBucketId', id);
+  sessionStorage.setItem('activeBucketName', name);
+  window.location.href = '/';
+}
+
+function openCreateModal() {
+  document.getElementById('create-modal').classList.remove('hidden');
+  document.getElementById('create-modal').classList.add('flex');
+}
+
+function closeCreateModal() {
+  document.getElementById('create-modal').classList.add('hidden');
+  document.getElementById('create-modal').classList.remove('flex');
+  document.getElementById('create-form').reset();
+}
+
+async function submitCreate(e) {
+  e.preventDefault();
+  const btn = document.getElementById('create-btn');
+  const btnText = document.getElementById('create-btn-text');
+  btn.disabled = true;
+  btnText.innerHTML = '<i class="fas fa-spinner fa-spin mr-1"></i> Adding...';
+
+  const payload = {
+    name: document.getElementById('f-name').value.trim(),
+    endpoint: document.getElementById('f-endpoint').value.trim(),
+    accessKeyId: document.getElementById('f-access-key').value.trim(),
+    secretAccessKey: document.getElementById('f-secret-key').value.trim(),
+    publicUrl: document.getElementById('f-public-url').value.trim(),
+    createOnCloudflare: document.getElementById('f-create-cf').checked,
+  };
+
+  try {
+    const res = await fetch('/api/buckets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || data.message || 'Failed to add bucket');
+    showToast('Bucket added successfully', 'success');
+    closeCreateModal();
+    loadBuckets();
+  } catch (err) {
+    showToast(err.message, 'error');
+  } finally {
+    btn.disabled = false;
+    btnText.textContent = 'Add Bucket';
+  }
+}
+
+async function deleteBucket(id, name) {
+  if (!confirm(`Remove "${name}" from panel?\n\nThis does NOT delete the bucket from Cloudflare.`)) return;
+  try {
+    const res = await fetch(`/api/buckets/${id}`, { method: 'DELETE' });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to remove bucket');
+    // Clear active bucket if it was the deleted one
+    if (sessionStorage.getItem('activeBucketId') === id) {
+      sessionStorage.removeItem('activeBucketId');
+      sessionStorage.removeItem('activeBucketName');
+    }
+    showToast('Bucket removed from panel', 'success');
+    loadBuckets();
+  } catch (err) {
+    showToast(err.message, 'error');
+  }
+}
+
+async function logout() {
+  await fetch('/auth/logout', { method: 'POST' });
+  sessionStorage.clear();
+  window.location.href = '/login';
+}
+
+function escHtml(str) {
+  return String(str).replace(/[&<>"']/g, c => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
+}
+
+function showToast(message, type = 'info') {
+  const container = document.getElementById('toast-container');
+  const colors = { success: 'bg-green-500', error: 'bg-red-500', info: 'bg-blue-500' };
+  const toast = document.createElement('div');
+  toast.className = `${colors[type] || colors.info} text-white px-4 py-3 rounded-xl shadow-lg text-sm flex items-center gap-2 animate-fade-in`;
+  toast.innerHTML = `<i class="fas fa-${type === 'success' ? 'check' : type === 'error' ? 'exclamation-circle' : 'info-circle'}"></i> ${escHtml(message)}`;
+  container.appendChild(toast);
+  setTimeout(() => toast.remove(), 4000);
+}
+
+loadBuckets();

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -38,7 +38,7 @@ async function loadBuckets() {
 
     if (buckets.length === 0) {
       list.innerHTML = `
-        <div class="text-center py-10 text-gray-400 dark:text-gray-500">
+        <div class="text-center py-10" style="color: var(--text-tertiary);">
           <i class="fas fa-database text-4xl mb-3 block opacity-30"></i>
           <p>No buckets yet. Add your first bucket.</p>
         </div>`;
@@ -46,19 +46,19 @@ async function loadBuckets() {
     }
 
     list.innerHTML = buckets.map(b => `
-      <div class="group flex items-center gap-4 p-4 bg-white dark:bg-gray-800 border border-gray-200 dark:border-gray-700 rounded-xl hover:border-blue-400 dark:hover:border-blue-500 hover:shadow-md transition-all cursor-pointer" onclick="selectBucket('${b.id}', '${escHtml(b.name)}')">
-        <div class="flex-shrink-0 w-10 h-10 bg-blue-50 dark:bg-blue-900/30 rounded-lg flex items-center justify-center">
-          <i class="fas fa-bucket text-blue-500 dark:text-blue-400"></i>
+      <div class="group flex items-center gap-4 p-4 border rounded-xl hover:shadow-md transition-all cursor-pointer" style="background-color: var(--bg-primary); border-color: var(--border-color);" onclick="selectBucket('${b.id}', '${escHtml(b.name)}')" onmouseover="this.style.borderColor='var(--primary-color)'" onmouseout="this.style.borderColor='var(--border-color)'">
+        <div class="flex-shrink-0 w-10 h-10 rounded-lg flex items-center justify-center" style="background-color: var(--bg-tertiary);">
+          <i class="fas fa-bucket" style="color: var(--primary-color);"></i>
         </div>
         <div class="flex-1 min-w-0">
           <p class="bucket-card-name font-semibold truncate">${escHtml(b.name)}</p>
           <p class="bucket-card-sub text-xs truncate">${new Date(b.createdAt).toLocaleDateString('id-ID', {day:'numeric',month:'short',year:'numeric'})}</p>
         </div>
         <div class="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
-          <button onclick="event.stopPropagation(); deleteBucket('${b.id}', '${escHtml(b.name)}')" class="p-1.5 text-gray-400 hover:text-red-500 transition-colors" title="Remove from panel">
+          <button onclick="event.stopPropagation(); deleteBucket('${b.id}', '${escHtml(b.name)}')" class="p-1.5 hover:text-red-500 transition-colors" style="color: var(--text-tertiary);" title="Remove from panel">
             <i class="fas fa-trash text-sm"></i>
           </button>
-          <i class="fas fa-chevron-right text-gray-300 dark:text-gray-600"></i>
+          <i class="fas fa-chevron-right" style="color: var(--text-tertiary);"></i>
         </div>
       </div>
     `).join('');

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -55,6 +55,9 @@ async function loadBuckets() {
           <p class="bucket-card-sub text-xs truncate">${new Date(b.createdAt).toLocaleDateString('id-ID', {day:'numeric',month:'short',year:'numeric'})}</p>
         </div>
         <div class="flex items-center gap-2 opacity-0 group-hover:opacity-100 transition-opacity">
+          <button onclick="event.stopPropagation(); syncBucket('${b.id}', '${escHtml(b.name)}')" class="p-1.5 hover:text-blue-500 transition-colors" style="color: var(--text-tertiary);" title="Sync public URL from Cloudflare">
+            <i class="fas fa-sync-alt text-sm"></i>
+          </button>
           <button onclick="event.stopPropagation(); deleteBucket('${b.id}', '${escHtml(b.name)}')" class="p-1.5 hover:text-red-500 transition-colors" style="color: var(--text-tertiary);" title="Remove from panel">
             <i class="fas fa-trash text-sm"></i>
           </button>
@@ -120,6 +123,19 @@ async function submitCreate(e) {
   } finally {
     btn.disabled = false;
     btnText.textContent = 'Add Bucket';
+  }
+}
+
+async function syncBucket(id, name) {
+  try {
+    const res = await fetch(`/api/buckets/${id}/sync`, { method: 'POST' });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.meta?.message || data.error || 'Sync failed');
+    const msg = data.data?.publicUrl ? `Public URL synced: ${data.data.publicUrl}` : 'No public domain found on Cloudflare';
+    showToast(msg, data.data?.publicUrl ? 'success' : 'info');
+    loadBuckets();
+  } catch (err) {
+    showToast(err.message, 'error');
   }
 }
 

--- a/public/js/bucket-selector.js
+++ b/public/js/bucket-selector.js
@@ -114,6 +114,110 @@ async function deleteBucket(id, name) {
   }
 }
 
+// --- Import from Cloudflare ---
+async function openImportModal() {
+  document.getElementById('import-modal').classList.remove('hidden');
+  document.getElementById('import-modal').classList.add('flex');
+  showImportStep(1);
+  loadCfBuckets();
+}
+
+function closeImportModal() {
+  document.getElementById('import-modal').classList.add('hidden');
+  document.getElementById('import-modal').classList.remove('flex');
+  document.getElementById('import-form').reset();
+}
+
+function showImportStep(step) {
+  document.getElementById('import-step-1').classList.toggle('hidden', step !== 1);
+  document.getElementById('import-step-2').classList.toggle('hidden', step !== 2);
+}
+
+function backToStep1() {
+  showImportStep(1);
+}
+
+async function loadCfBuckets() {
+  const list = document.getElementById('cf-bucket-list');
+  list.innerHTML = '<div class="flex items-center justify-center py-8"><i class="fas fa-spinner fa-spin text-gray-400 text-2xl"></i></div>';
+  try {
+    const res = await fetch('/api/buckets/cf-list');
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || 'Failed to fetch from Cloudflare');
+    const buckets = data.data || [];
+    if (buckets.length === 0) {
+      list.innerHTML = '<p class="text-center text-gray-400 py-6">No buckets found in your Cloudflare account.</p>';
+      return;
+    }
+    list.innerHTML = buckets.map(b => `
+      <div class="flex items-center justify-between p-3 border rounded-xl ${
+        b.alreadyAdded
+          ? 'border-gray-200 dark:border-gray-700 opacity-50'
+          : 'border-gray-200 dark:border-gray-700 hover:border-orange-400 cursor-pointer'
+      }" ${!b.alreadyAdded ? `onclick="selectCfBucket('${escHtml(b.name)}', '${escHtml(b.endpoint)}')"`  : ''}>
+        <div class="flex items-center gap-3">
+          <i class="fas fa-bucket text-orange-400"></i>
+          <div>
+            <p class="font-medium text-gray-900 dark:text-white text-sm">${escHtml(b.name)}</p>
+            <p class="text-xs text-gray-400">${b.creationDate ? new Date(b.creationDate).toLocaleDateString() : ''}</p>
+          </div>
+        </div>
+        ${b.alreadyAdded
+          ? '<span class="text-xs text-green-500 font-medium"><i class="fas fa-check mr-1"></i>Added</span>'
+          : '<i class="fas fa-chevron-right text-gray-300"></i>'
+        }
+      </div>
+    `).join('');
+  } catch (err) {
+    list.innerHTML = `<div class="text-center py-6 text-red-400"><i class="fas fa-exclamation-circle mr-2"></i>${escHtml(err.message)}</div>`;
+  }
+}
+
+function selectCfBucket(name, endpoint) {
+  document.getElementById('i-name').value = name;
+  document.getElementById('i-endpoint').value = endpoint;
+  document.getElementById('import-bucket-name-label').textContent = name;
+  document.getElementById('import-form').reset();
+  document.getElementById('i-name').value = name;
+  document.getElementById('i-endpoint').value = endpoint;
+  showImportStep(2);
+}
+
+async function submitImport(e) {
+  e.preventDefault();
+  const btn = document.getElementById('import-btn');
+  const btnText = document.getElementById('import-btn-text');
+  btn.disabled = true;
+  btnText.innerHTML = '<i class="fas fa-spinner fa-spin mr-1"></i> Adding...';
+
+  const payload = {
+    name: document.getElementById('i-name').value,
+    endpoint: document.getElementById('i-endpoint').value,
+    accessKeyId: document.getElementById('i-access-key').value.trim(),
+    secretAccessKey: document.getElementById('i-secret-key').value.trim(),
+    publicUrl: document.getElementById('i-public-url').value.trim(),
+    createOnCloudflare: false,
+  };
+
+  try {
+    const res = await fetch('/api/buckets', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    const data = await res.json();
+    if (!res.ok) throw new Error(data.error || data.message || 'Failed to add bucket');
+    showToast('Bucket imported successfully', 'success');
+    closeImportModal();
+    loadBuckets();
+  } catch (err) {
+    showToast(err.message, 'error');
+  } finally {
+    btn.disabled = false;
+    btnText.textContent = 'Add Bucket';
+  }
+}
+
 async function logout() {
   await fetch('/auth/logout', { method: 'POST' });
   sessionStorage.clear();

--- a/public/js/file-manager.js
+++ b/public/js/file-manager.js
@@ -209,6 +209,11 @@ document.addEventListener('DOMContentLoaded', () => {
                 hasMoreFiles = !!nextToken;
             }
             allFiles = isRefresh ? files : [...allFiles, ...files];
+            // Normalize url field: API returns publicUrl + presignedUrl, frontend uses file.url
+            allFiles = allFiles.map(f => ({
+                ...f,
+                url: f.url || f.publicUrl || f.presignedUrl || f.downloadUrl || '',
+            }));
 
             filterAndDisplayFiles();
             updateFilterCounts();
@@ -472,6 +477,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 
                 if (result.success && result.data && result.data.file) {
                     const newFile = result.data.file;
+                    newFile.url = newFile.url || newFile.publicUrl || newFile.presignedUrl || newFile.downloadUrl || '';
                     const newCard = createFileCard(newFile);
                     
                     // Ganti placeholder dengan kartu yang sebenarnya

--- a/public/js/file-manager.js
+++ b/public/js/file-manager.js
@@ -3,6 +3,30 @@
  * Handles file upload, display, and management functionality
  */
 
+// --- Bucket Context ---
+// Redirect to bucket selector if no active bucket
+const _activeBucketId = sessionStorage.getItem('activeBucketId');
+const _activeBucketName = sessionStorage.getItem('activeBucketName');
+if (!_activeBucketId) {
+  window.location.href = '/bucket-selector';
+}
+
+// Patch fetch to always inject X-Bucket-ID for API calls
+const _origFetch = window.fetch.bind(window);
+window.fetch = function(input, init = {}) {
+  const url = typeof input === 'string' ? input : input.url;
+  if (_activeBucketId && (url.startsWith('/r2') || url.startsWith('/api'))) {
+    init.headers = Object.assign({}, init.headers, { 'X-Bucket-ID': _activeBucketId });
+  }
+  return _origFetch(input, init);
+};
+
+// Show active bucket name in header
+document.addEventListener('DOMContentLoaded', () => {
+  const el = document.getElementById('active-bucket-name');
+  if (el && _activeBucketName) el.textContent = _activeBucketName;
+});
+
 document.addEventListener('DOMContentLoaded', () => {
     // Configuration & State
     let isLoading = false;

--- a/public/js/file-manager.js
+++ b/public/js/file-manager.js
@@ -720,13 +720,12 @@ document.addEventListener('DOMContentLoaded', () => {
         allFiles.forEach(file => {
             counts.all++;
             const type = getFileType(file.contentType);
-            if (counts.hasOwnProperty(type)) {
-                counts[type]++;
-            }
+            if (counts.hasOwnProperty(type)) counts[type]++;
         });
+        const suffix = hasMoreFiles ? '+' : '';
         for (const type in counts) {
             const el = document.getElementById(`count${type.charAt(0).toUpperCase() + type.slice(1)}`);
-            if (el) el.textContent = counts[type];
+            if (el) el.textContent = counts[type] + (type === 'all' ? suffix : '');
         }
     }
 

--- a/public/js/file-manager.js
+++ b/public/js/file-manager.js
@@ -1044,11 +1044,25 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     // --- App Initialization ---
+    async function fetchTotalCount() {
+        try {
+            const res = await fetchWithAutoRefresh('/api/stats/count');
+            if (!res.ok) return;
+            const data = await res.json();
+            const total = data.data?.totalFiles ?? data.totalFiles;
+            if (total !== undefined) {
+                const el = document.getElementById('countAll');
+                if (el) el.textContent = total;
+            }
+        } catch (e) { /* non-fatal */ }
+    }
+
     async function init() {
         const isAuthenticated = await checkAuth();
         if (isAuthenticated) {
             setupEventListeners();
             loadFiles(true);
+            fetchTotalCount(); // background — get real total without blocking UI
         }
     }
 

--- a/public/js/file-manager.js
+++ b/public/js/file-manager.js
@@ -209,7 +209,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 hasMoreFiles = !!nextToken;
             }
             allFiles = isRefresh ? files : [...allFiles, ...files];
-            // Normalize url field: API returns publicUrl + presignedUrl, frontend uses file.url
+            // Normalize url field: publicUrl (permanent) > presignedUrl (for img display) > proxy download
             allFiles = allFiles.map(f => ({
                 ...f,
                 url: f.url || f.publicUrl || f.presignedUrl || f.downloadUrl || '',

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -118,6 +118,8 @@ class ThemeManager {
 // Initialize theme manager when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
     window.themeManager = new ThemeManager();
+    // Expose global shortcut for inline onclick handlers
+    window.toggleTheme = () => window.themeManager.toggleTheme();
 });
 
 // Export for use in other scripts

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -45,15 +45,23 @@ class ThemeManager {
         const header = document.querySelector('header');
         
         if (headerActions) {
-            const lastButton = headerActions.lastElementChild;
-            headerActions.insertBefore(toggleBtn, lastButton);
+            // Insert before the last button in header actions
+            headerActions.insertBefore(toggleBtn, headerActions.lastElementChild);
         } else if (headerGap) {
+            // Append to header gap container
             headerGap.appendChild(toggleBtn);
         } else if (header) {
-            header.appendChild(toggleBtn);
+            // Create a container for the toggle if header exists but no suitable container
+            const container = document.createElement('div');
+            container.className = 'absolute top-4 right-4';
+            container.appendChild(toggleBtn);
+            header.appendChild(container);
         } else {
             // Fallback: floating toggle — safe, never inside page content
-            toggleBtn.className += ' fixed top-4 right-4 z-50 bg-white border border-gray-300 shadow-lg';
+            toggleBtn.className += ' fixed top-4 right-4 z-50 shadow-lg';
+            toggleBtn.style.backgroundColor = 'var(--bg-primary)';
+            toggleBtn.style.borderColor = 'var(--border-color)';
+            toggleBtn.style.color = 'var(--text-primary)';
             document.body.appendChild(toggleBtn);
         }
     }

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -1,14 +1,14 @@
 // Universal Theme Management
 class ThemeManager {
     constructor() {
-        this.init();
+        // Apply theme immediately (before DOM ready) to avoid flash
+        this.currentTheme = localStorage.getItem('theme') || 'light';
+        document.documentElement.setAttribute('data-theme', this.currentTheme);
     }
 
     init() {
-        // Get saved theme or default to light
-        this.currentTheme = localStorage.getItem('theme') || 'light';
-        this.applyTheme(this.currentTheme);
         this.createToggleButton();
+        this.updateToggleIcon();
         this.bindEvents();
     }
 
@@ -118,6 +118,7 @@ class ThemeManager {
 // Initialize theme manager when DOM is loaded
 document.addEventListener('DOMContentLoaded', () => {
     window.themeManager = new ThemeManager();
+    window.themeManager.init();
     // Expose global shortcut for inline onclick handlers
     window.toggleTheme = () => window.themeManager.toggleTheme();
 });

--- a/public/js/theme.js
+++ b/public/js/theme.js
@@ -40,12 +40,11 @@ class ThemeManager {
 
     insertToggleButton(toggleBtn) {
         // Try different locations based on page structure
-        const headerActions = document.querySelector('.flex.items-center.justify-end.gap-2');
-        const headerGap = document.querySelector('.flex.items-center.gap-2');
+        const headerActions = document.querySelector('header .flex.items-center.justify-end.gap-2');
+        const headerGap = document.querySelector('header .flex.items-center.gap-2');
         const header = document.querySelector('header');
         
         if (headerActions) {
-            // Insert before the last button (usually logout)
             const lastButton = headerActions.lastElementChild;
             headerActions.insertBefore(toggleBtn, lastButton);
         } else if (headerGap) {
@@ -53,7 +52,7 @@ class ThemeManager {
         } else if (header) {
             header.appendChild(toggleBtn);
         } else {
-            // Fallback: create floating toggle
+            // Fallback: floating toggle — safe, never inside page content
             toggleBtn.className += ' fixed top-4 right-4 z-50 bg-white border border-gray-300 shadow-lg';
             document.body.appendChild(toggleBtn);
         }

--- a/public/login.html
+++ b/public/login.html
@@ -3,11 +3,20 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Login - Qiblat File Manager</title>
+  <title>Login — R2 Panel</title>
   <script src="https://cdn.tailwindcss.com"></script>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css">
   <link rel="stylesheet" href="/css/main.css">
   <script src="/js/theme.js"></script>
+  <style>
+    .theme-toggle-login {
+      position: fixed; top: 1rem; right: 1rem;
+      background-color: var(--bg-primary); border: 1px solid var(--border-color);
+      color: var(--text-secondary); border-radius: 0.5rem;
+      padding: 0.5rem 0.75rem; cursor: pointer; transition: all 0.2s; z-index: 50;
+    }
+    .theme-toggle-login:hover { background-color: var(--bg-tertiary); }
+  </style>
 </head>
 <body class="min-h-screen flex items-center justify-center font-sans" style="background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-primary) 50%, var(--bg-tertiary) 100%);">
   
@@ -18,7 +27,7 @@
       <div class="mx-auto w-16 h-16 rounded-full flex items-center justify-center mb-4" style="background-color: var(--bg-tertiary);">
         <i class="fas fa-cloud-upload-alt text-2xl" style="color: var(--primary-color);"></i>
       </div>
-      <h1 class="text-2xl font-bold mb-2" style="color: var(--text-primary);">Qiblat File Manager</h1>
+      <h1 class="text-2xl font-bold mb-2" style="color: var(--text-primary);">R2 Storage Panel</h1>
       <p style="color: var(--text-secondary);">Sign in to access your files</p>
     </div>
 

--- a/public/login.html
+++ b/public/login.html
@@ -9,51 +9,54 @@
   <link rel="stylesheet" href="/css/main.css">
   <script src="/js/theme.js"></script>
 </head>
-<body class="bg-gradient-to-br from-indigo-100 via-white to-cyan-100 min-h-screen flex items-center justify-center font-sans">
+<body class="min-h-screen flex items-center justify-center font-sans" style="background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-primary) 50%, var(--bg-tertiary) 100%);">
   
   <div id="toast-container" class="fixed bottom-5 right-5 z-50 flex flex-col gap-3"></div>
 
-  <div class="bg-white p-8 rounded-2xl shadow-xl w-full max-w-md">
+  <div class="p-8 rounded-2xl shadow-xl w-full max-w-md" style="background-color: var(--bg-primary);">
     <div class="text-center mb-8">
-      <div class="mx-auto w-16 h-16 bg-indigo-100 rounded-full flex items-center justify-center mb-4">
-        <i class="fas fa-cloud-upload-alt text-2xl text-indigo-600"></i>
+      <div class="mx-auto w-16 h-16 rounded-full flex items-center justify-center mb-4" style="background-color: var(--bg-tertiary);">
+        <i class="fas fa-cloud-upload-alt text-2xl" style="color: var(--primary-color);"></i>
       </div>
-      <h1 class="text-2xl font-bold text-gray-800 mb-2">Qiblat File Manager</h1>
-      <p class="text-gray-600">Sign in to access your files</p>
+      <h1 class="text-2xl font-bold mb-2" style="color: var(--text-primary);">Qiblat File Manager</h1>
+      <p style="color: var(--text-secondary);">Sign in to access your files</p>
     </div>
 
     <form id="loginForm" class="space-y-6">
       <div>
-        <label for="username" class="block text-sm font-medium text-gray-700 mb-2">Username</label>
+        <label for="username" class="block text-sm font-medium mb-2" style="color: var(--text-secondary);">Username</label>
         <div class="relative">
           <input 
             type="text" 
             id="username" 
             name="username" 
             required
-            class="w-full px-4 py-3 pl-10 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors"
+            class="w-full px-4 py-3 pl-10 border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors"
+            style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);"
             placeholder="Enter your username"
           >
-          <i class="fas fa-user absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></i>
+          <i class="fas fa-user absolute left-3 top-1/2 -translate-y-1/2" style="color: var(--text-tertiary);"></i>
         </div>
       </div>
 
       <div>
-        <label for="password" class="block text-sm font-medium text-gray-700 mb-2">Password</label>
+        <label for="password" class="block text-sm font-medium mb-2" style="color: var(--text-secondary);">Password</label>
         <div class="relative">
           <input 
             type="password" 
             id="password" 
             name="password" 
             required
-            class="w-full px-4 py-3 pl-10 pr-10 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors"
+            class="w-full px-4 py-3 pl-10 pr-10 border rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 transition-colors"
+            style="background-color: var(--bg-primary); border-color: var(--border-color); color: var(--text-primary);"
             placeholder="Enter your password"
           >
-          <i class="fas fa-lock absolute left-3 top-1/2 -translate-y-1/2 text-gray-400"></i>
+          <i class="fas fa-lock absolute left-3 top-1/2 -translate-y-1/2" style="color: var(--text-tertiary);"></i>
           <button 
             type="button" 
             id="togglePassword" 
-            class="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors"
+            class="absolute right-3 top-1/2 -translate-y-1/2 transition-colors"
+            style="color: var(--text-tertiary);"
           >
             <i class="fas fa-eye"></i>
           </button>

--- a/public/stats.html
+++ b/public/stats.html
@@ -9,8 +9,11 @@
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <link rel="stylesheet" href="/css/main.css">
     <script src="/js/theme.js"></script>
+    <style>
+      .stat-icon-wrap { background-color: var(--bg-tertiary); border-radius: 9999px; padding: 0.75rem; }
+    </style>
 </head>
-<body class="font-sans transition-colors duration-300">
+<body class="font-sans transition-colors duration-300" style="background-color: var(--bg-secondary); color: var(--text-primary);">
 
     <!-- Toast container -->
     <div id="toast-container" class="fixed bottom-5 right-5 z-50 flex flex-col gap-3"></div>
@@ -73,8 +76,8 @@
                             <p class="text-sm font-medium" style="color: var(--text-secondary);">Storage Used</p>
                             <p id="totalSizeCard" class="text-2xl font-bold" style="color: var(--text-primary);">-</p>
                         </div>
-                        <div class="bg-blue-100 dark:bg-blue-900 p-3 rounded-full">
-                            <i class="fas fa-hdd text-blue-600 dark:text-blue-400 text-xl"></i>
+                        <div class="stat-icon-wrap">
+                            <i class="fas fa-hdd text-blue-500 text-xl"></i>
                         </div>
                     </div>
                     <div class="mt-4">
@@ -94,8 +97,8 @@
                             <p class="text-sm font-medium" style="color: var(--text-secondary);">Total Files</p>
                             <p id="totalFilesCard" class="text-2xl font-bold" style="color: var(--text-primary);">-</p>
                         </div>
-                        <div class="bg-green-100 dark:bg-green-900 p-3 rounded-full">
-                            <i class="fas fa-file text-green-600 dark:text-green-400 text-xl"></i>
+                        <div class="stat-icon-wrap">
+                            <i class="fas fa-file text-green-500 text-xl"></i>
                         </div>
                     </div>
                 </div>
@@ -107,8 +110,8 @@
                             <p class="text-sm font-medium" style="color: var(--text-secondary);">Free Tier Limit</p>
                             <p id="freeTierLimitCard" class="text-2xl font-bold" style="color: var(--text-primary);">10 GB</p>
                         </div>
-                        <div class="bg-yellow-100 dark:bg-yellow-900 p-3 rounded-full">
-                            <i class="fas fa-exclamation-triangle text-yellow-600 dark:text-yellow-400 text-xl"></i>
+                        <div class="stat-icon-wrap">
+                            <i class="fas fa-exclamation-triangle text-yellow-500 text-xl"></i>
                         </div>
                     </div>
                 </div>
@@ -120,8 +123,8 @@
                             <p class="text-sm font-medium" style="color: var(--text-secondary);">Remaining</p>
                             <p id="remainingSpaceCard" class="text-2xl font-bold" style="color: var(--text-primary);">-</p>
                         </div>
-                        <div class="bg-purple-100 dark:bg-purple-900 p-3 rounded-full">
-                            <i class="fas fa-database text-purple-600 dark:text-purple-400 text-xl"></i>
+                        <div class="stat-icon-wrap">
+                            <i class="fas fa-database text-purple-500 text-xl"></i>
                         </div>
                     </div>
                 </div>

--- a/public/webp-converter.html
+++ b/public/webp-converter.html
@@ -12,35 +12,35 @@
     <link rel="stylesheet" href="/css/main.css">
     <script src="/js/theme.js"></script>
 </head>
-<body class="bg-gray-50 min-h-screen">
+<body class="min-h-screen" style="background-color: var(--bg-secondary);">
 
     <div id="toast-container" class="fixed bottom-5 right-5 z-[100] flex flex-col gap-3"></div>
 
     <div class="container mx-auto px-4 sm:px-6 lg:px-8 py-8 max-w-4xl">
-        <header class="bg-white shadow-md rounded-xl p-4 sm:p-6 mb-8">
+        <header class="shadow-md rounded-xl p-4 sm:p-6 mb-8" style="background-color: var(--bg-primary);">
             <div class="flex flex-wrap justify-between items-center gap-y-4">
                 <div class="flex items-center">
                     <span class="text-white bg-green-600 rounded-lg p-2 mr-3">
                         <i class="fas fa-image"></i>
                     </span>
                     <div>
-                        <h1 class="text-xl sm:text-2xl font-bold text-gray-800">
+                        <h1 class="text-xl sm:text-2xl font-bold" style="color: var(--text-primary);">
                             WebP Image Converter
                         </h1>
-                        <p class="text-gray-500 text-sm hidden sm:block">Convert and upload images to WebP format with CDN.</p>
+                        <p class="text-sm hidden sm:block" style="color: var(--text-secondary);">Convert and upload images to WebP format with CDN.</p>
                     </div>
                 </div>
                 
                 <div class="flex items-center gap-2">
-                    <a href="/" class="bg-gray-200 text-gray-700 px-4 py-2.5 rounded-lg hover:bg-gray-300 transition-colors text-sm font-semibold flex items-center gap-2">
+                    <a href="/" class="px-4 py-2.5 rounded-lg transition-colors text-sm font-semibold flex items-center gap-2" style="background-color: var(--bg-secondary); color: var(--text-primary);">
                         <i class="fas fa-arrow-left"></i>
                         <span class="hidden sm:inline">Back</span>
                         <span class="sm:hidden">Back</span>
                     </a>
-                    <a href="/api-docs" class="bg-gray-200 text-gray-700 p-2.5 rounded-lg hover:bg-gray-300 transition-colors" title="Dokumentasi API">
+                    <a href="/api-docs" class="p-2.5 rounded-lg transition-colors" style="background-color: var(--bg-secondary); color: var(--text-primary);" title="Dokumentasi API">
                         <i class="fas fa-code"></i>
                     </a>
-                    <button id="logoutBtn" class="bg-gray-200 text-gray-700 p-2.5 rounded-lg hover:bg-red-200 hover:text-red-700 transition-colors" title="Keluar">
+                    <button id="logoutBtn" class="p-2.5 rounded-lg hover:bg-red-200 hover:text-red-700 transition-colors" style="background-color: var(--bg-secondary); color: var(--text-primary);" title="Keluar">
                         <i class="fas fa-sign-out-alt"></i>
                     </button>
                 </div>
@@ -48,14 +48,14 @@
         </header>
 
         <div id="authSection" class="text-center py-20">
-            <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 mx-auto mb-4"></div>
-            <p class="text-gray-600">Memeriksa autentikasi...</p>
+            <div class="animate-spin rounded-full h-8 w-8 border-b-2 mx-auto mb-4" style="border-color: var(--primary-color);"></div>
+            <p style="color: var(--text-secondary);">Memeriksa autentikasi...</p>
         </div>
 
         <div id="loginSection" class="text-center py-20 hidden">
-            <div class="max-w-md mx-auto bg-white rounded-lg shadow-md p-8">
-                <h2 class="text-2xl font-bold text-gray-800 mb-4">Login Required</h2>
-                <p class="text-gray-600 mb-6">You need to login to use the WebP converter.</p>
+            <div class="max-w-md mx-auto rounded-lg shadow-md p-8" style="background-color: var(--bg-primary);">
+                <h2 class="text-2xl font-bold mb-4" style="color: var(--text-primary);">Login Required</h2>
+                <p class="mb-6" style="color: var(--text-secondary);">You need to login to use the WebP converter.</p>
                 <a href="/login" class="bg-indigo-600 text-white px-6 py-2 rounded-lg hover:bg-indigo-700 transition-colors inline-flex items-center gap-2">
                     <i class="fas fa-sign-in-alt"></i>
                     Login
@@ -65,18 +65,18 @@
 
         <div id="mainContent" class="hidden">
             <!-- Upload Section -->
-            <div class="bg-white rounded-xl shadow-md p-6 mb-8">
-                <h2 class="text-xl font-bold text-gray-800 mb-4 flex items-center gap-2">
+            <div class="rounded-xl shadow-md p-6 mb-8" style="background-color: var(--bg-primary);">
+                <h2 class="text-xl font-bold mb-4 flex items-center gap-2" style="color: var(--text-primary);">
                     <i class="fas fa-upload text-green-600"></i>
                     Upload Image
                 </h2>
                 
-                <div id="dropArea" class="border-2 border-dashed border-gray-300 rounded-lg p-8 text-center transition-all hover:border-indigo-500 hover:bg-indigo-50">
+                <div id="dropArea" class="border-2 border-dashed rounded-lg p-8 text-center transition-all" style="border-color: var(--border-color);" onmouseover="this.style.borderColor='var(--primary-color)'; this.style.backgroundColor='var(--bg-tertiary)'" onmouseout="this.style.borderColor='var(--border-color)'; this.style.backgroundColor='transparent'">
                     <input type="file" id="fileInput" class="hidden" accept="image/*" multiple>
                     <div class="mb-4">
-                        <i class="fas fa-cloud-upload-alt text-4xl text-gray-400 mb-4"></i>
-                        <p class="text-lg font-medium text-gray-700">Drag & drop your images here</p>
-                        <p class="text-gray-500">or click to browse (multiple files supported)</p>
+                        <i class="fas fa-cloud-upload-alt text-4xl mb-4" style="color: var(--text-tertiary);"></i>
+                        <p class="text-lg font-medium" style="color: var(--text-primary);">Drag & drop your images here</p>
+                        <p style="color: var(--text-secondary);">or click to browse (multiple files supported)</p>
                     </div>
                     <button id="browseButton" class="bg-indigo-600 text-white px-6 py-2 rounded-lg hover:bg-indigo-700 transition-colors">
                         <i class="fas fa-folder-open mr-2"></i>
@@ -85,7 +85,7 @@
                 </div>
 
                 <div id="filePreview" class="mt-6 hidden">
-                    <h3 class="text-lg font-semibold text-gray-800 mb-3">Selected Images:</h3>
+                    <h3 class="text-lg font-semibold mb-3" style="color: var(--text-primary);">Selected Images:</h3>
                     <div id="previewContent" class="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 gap-4">
                         <!-- Preview cards will be inserted here -->
                     </div>
@@ -93,26 +93,26 @@
             </div>
 
             <!-- Quality Section -->
-            <div id="qualitySection" class="bg-white rounded-xl shadow-md p-6 mb-8 hidden">
-                <h2 class="text-xl font-bold text-gray-800 mb-4 flex items-center gap-2">
+            <div id="qualitySection" class="rounded-xl shadow-md p-6 mb-8 hidden" style="background-color: var(--bg-primary);">
+                <h2 class="text-xl font-bold mb-4 flex items-center gap-2" style="color: var(--text-primary);">
                     <i class="fas fa-sliders-h text-blue-600"></i>
                     WebP Quality Settings
                 </h2>
                 
                 <div class="space-y-4">
                     <div>
-                        <label for="qualitySlider" class="block text-sm font-medium text-gray-700 mb-2">
-                            Quality: <span id="qualityValue" class="font-bold text-indigo-600">80</span>%
+                        <label for="qualitySlider" class="block text-sm font-medium mb-2" style="color: var(--text-secondary);">
+                            Quality: <span id="qualityValue" class="font-bold" style="color: var(--primary-color);">80</span>%
                         </label>
                         <input type="range" id="qualitySlider" class="quality-slider" min="10" max="100" value="80">
-                        <div class="flex justify-between text-xs text-gray-500 mt-1">
+                        <div class="flex justify-between text-xs mt-1" style="color: var(--text-tertiary);">
                             <span>Smaller file (10%)</span>
                             <span>Best quality (100%)</span>
                         </div>
                     </div>
                     
-                    <div class="bg-blue-50 border border-blue-200 rounded-lg p-3">
-                        <p class="text-sm text-blue-800">
+                    <div class="border rounded-lg p-3" style="background-color: var(--info-bg); border-color: var(--info-border);">
+                        <p class="text-sm" style="color: var(--info-text);">
                             <i class="fas fa-info-circle mr-1"></i>
                             <span id="selectedCount">0</span> image(s) selected for conversion
                         </p>
@@ -126,19 +126,19 @@
             </div>
 
             <!-- Progress Section -->
-            <div id="progressSection" class="bg-white rounded-xl shadow-md p-6 mb-8 hidden">
-                <h2 class="text-xl font-bold text-gray-800 mb-4 flex items-center gap-2">
+            <div id="progressSection" class="rounded-xl shadow-md p-6 mb-8 hidden" style="background-color: var(--bg-primary);">
+                <h2 class="text-xl font-bold mb-4 flex items-center gap-2" style="color: var(--text-primary);">
                     <i class="fas fa-spinner animate-spin text-blue-600"></i>
                     Processing...
                 </h2>
-                <div class="w-full bg-gray-200 rounded-full h-2">
+                <div class="w-full rounded-full h-2" style="background-color: var(--bg-secondary);">
                     <div id="progressBar" class="bg-blue-600 h-2 rounded-full transition-all duration-300" style="width: 0%"></div>
                 </div>
-                <p id="progressText" class="text-sm text-gray-600 mt-2">Preparing upload...</p>
+                <p id="progressText" class="text-sm mt-2" style="color: var(--text-secondary);">Preparing upload...</p>
             </div>
 
             <!-- Result Section -->
-            <div id="resultSection" class="bg-white rounded-xl shadow-md p-6 hidden">
+            <div id="resultSection" class="rounded-xl shadow-md p-6 hidden" style="background-color: var(--bg-primary);">
                 <div id="resultContent">
                     <!-- Results will be inserted here -->
                 </div>

--- a/server.js
+++ b/server.js
@@ -45,6 +45,11 @@ app.use('/api', async (req, res, next) => {
       return await r2Handler(req, res);
     }
     
+    if (path === '/buckets' || path.startsWith('/buckets/')) {
+      const bucketsHandler = require('./api/buckets');
+      return await bucketsHandler(req, res);
+    }
+    
     if (path === '/upload-multiple') {
       const uploadMultipleHandler = require('./api/upload-multiple');
       return await uploadMultipleHandler(req, res);
@@ -111,6 +116,10 @@ app.get('/login', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'login.html'));
 });
 
+
+app.get('/bucket-selector', (req, res) => {
+  res.sendFile(path.join(__dirname, 'public', 'bucket-selector.html'));
+});
 
 app.get('/webp-converter', (req, res) => {
   res.sendFile(path.join(__dirname, 'public', 'webp-converter.html'));


### PR DESCRIPTION
## Summary
Adds multi-bucket support to the R2 panel. Users can now manage multiple Cloudflare R2 buckets from a single panel.

## Changes
- **`api/r2-client.js`** — refactored to factory pattern with `resolveClientAndBucket()`
- **`api/bucket-store.js`** — new: CRUD for `buckets.json` stored in master R2 bucket (no external DB needed, Vercel free compatible)
- **`api/buckets.js`** — new: `GET/POST /api/buckets`, `DELETE /api/buckets/:id`, optional create via Cloudflare API
- **All API handlers** (r2, files, upload, upload-multiple, stats) — updated to resolve bucket from `X-Bucket-ID` header, fallback to master bucket
- **`/bucket-selector`** — new page: list, add, delete buckets after login
- **`file-manager.js`** — auto-redirect to bucket selector if no active bucket; patches `fetch` to inject `X-Bucket-ID` on all API calls
- **`index.html`** — shows active bucket name in header with switch link
- **`.env.example`** — added `CF_ACCOUNT_ID` and `CF_API_TOKEN`
- **Dependencies** — fixed 24 security vulnerabilities, added `uuid`, updated Node engine to `>=22.x`

## New ENV vars required
```
CF_ACCOUNT_ID=your-cloudflare-account-id
CF_API_TOKEN=your-cloudflare-api-token
```

## API
- `GET /api/buckets` — list buckets (no credentials exposed)
- `POST /api/buckets` — add bucket (with optional CF create)
- `DELETE /api/buckets/:id` — remove from panel
- All file endpoints accept `X-Bucket-ID` header to target specific bucket