### PR TITLE
Security fix + open-source hardening

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,44 @@
+name: Bug report
+description: Report a problem with R2 Storage Panel
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: How can we reproduce the behavior?
+      placeholder: |
+        1. Go to ...
+        2. Click on ...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: input
+    id: deployment
+    attributes:
+      label: Deployment
+      description: Standalone Node or Vercel? Node version?
+      placeholder: "Standalone Node, Node 22"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs
+      description: Relevant logs or screenshots. Do NOT include secrets, tokens, or API keys.
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/soimalfath/r2-storage-panel/security/advisories/new
+    about: Please report security issues privately. Do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: Feature request
+description: Suggest an idea for R2 Storage Panel
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem does this feature solve?
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe the solution you'd like.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Related issues
+
+<!-- e.g. Closes #123 -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Refactor
+- [ ] Documentation
+- [ ] Other
+
+## Testing
+
+<!-- How did you verify this change? Commands run, flows tested. -->
+
+## Checklist
+
+- [ ] The app starts cleanly (`npm start`)
+- [ ] I manually tested the affected flows
+- [ ] No secrets, `.env` files, or credentials are committed
+- [ ] Documentation updated where relevant

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,58 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes
+- Focusing on what is best for the overall community
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards
+and will take appropriate and fair corrective action in response to any behavior
+they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also applies when
+an individual is officially representing the community in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers through the repository's **Security** tab
+or by opening a private report. All complaints will be reviewed and
+investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+https://www.contributor-covenant.org/version/2/1/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,65 @@
+# Contributing to R2 Storage Panel
+
+Thanks for your interest in contributing. This guide explains how to propose
+changes.
+
+## Getting Started
+
+1. Fork the repository and clone your fork.
+2. Install dependencies:
+   ```bash
+   npm install
+   ```
+3. Copy the environment template and fill in your own R2 credentials:
+   ```bash
+   cp .env.example .env
+   ```
+4. Run the development server:
+   ```bash
+   npm run dev
+   ```
+
+## Branching
+
+- Create a branch from the default branch for your work.
+- Use descriptive prefixes: `feature/`, `fix/`, `refactor/`, `chore/`, `docs/`.
+- Keep each branch focused on a single change.
+
+## Commit Messages
+
+Follow [Conventional Commits](https://www.conventionalcommits.org/):
+
+```
+feat: add multi-bucket selector
+fix: prevent API key leak on /api/apikey
+docs: clarify deployment steps
+```
+
+Keep commits atomic and write messages in English.
+
+## Pull Requests
+
+- Target the default branch.
+- Describe what changed and why. Link related issues with `Closes #<number>`.
+- Make sure the app starts cleanly (`npm start`) and that you have manually
+  tested the affected flows.
+- Do not include unrelated formatting churn.
+- Never commit secrets, `.env` files, or credentials.
+
+## Code Style
+
+- Keep functions small and single-purpose.
+- Validate all client input on the server.
+- Use parameterized/SDK calls — never build queries or commands by string
+  concatenation.
+- Prefer clear names over comments; comment only non-obvious decisions.
+
+## Reporting Bugs and Requesting Features
+
+Use the issue templates under **New issue**. For security vulnerabilities, do
+not open a public issue — follow [SECURITY.md](SECURITY.md) instead.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+[MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Soim Alfath
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,178 +1,163 @@
-# Cloudflare R2 File Service
+# R2 Storage Panel
 
-Layanan pengunggahan file sederhana menggunakan Express.js dengan antarmuka pengguna modern berbasis Tailwind CSS, yang khusus menggunakan Cloudflare R2 untuk penyimpanan cloud. Dilengkapi dengan sistem autentikasi JWT yang aman.
+A self-hostable file manager for **Cloudflare R2**, built with Express.js and a modern Tailwind CSS interface. It ships with secure JWT authentication, a public API guarded by API keys, drag-and-drop uploads, WebP conversion, and storage statistics.
 
-## Fitur Utama
-- **Autentikasi Aman**: Sistem login/logout dengan JWT access & refresh tokens
-- **Unggah file**: Drag & drop atau pemilihan file dengan progress bar
-- **Manajemen File**: Tampilkan, unduh, dan hapus file dengan pagination
-- **Sharing**: Buat URL publik dan temporary URL untuk berbagi file
-- **UI Modern**: Antarmuka responsif dengan Tailwind CSS dan Font Awesome
-- **Security**: HTTP-only cookies, token refresh otomatis
+> Works as a standalone Node server or as Vercel serverless functions.
 
-## Cara Setup
+## Features
 
-### 1. Instal dependensi
+- **Secure authentication** — JWT access & refresh tokens stored in HTTP-only cookies
+- **File uploads** — drag & drop or file picker with progress feedback
+- **File management** — list, download, and delete files with pagination
+- **Sharing** — generate public URLs and temporary presigned URLs
+- **WebP conversion** — convert images to WebP on upload (via `sharp`)
+- **Storage stats** — capacity and file-count dashboard
+- **Public API** — API-key protected endpoints for external integrations
+- **Modern UI** — responsive interface with Tailwind CSS and Font Awesome
+
+## Tech Stack
+
+- **Backend:** Node.js + Express, JWT, bcryptjs
+- **Frontend:** Vanilla JavaScript, Tailwind CSS, Font Awesome
+- **Storage:** Cloudflare R2 (S3-compatible, via AWS SDK v3)
+- **Deployment:** standalone Node or Vercel serverless functions
+
+## Requirements
+
+- Node.js >= 22
+- A Cloudflare R2 bucket and access credentials
+
+## Getting Started
+
+### 1. Install dependencies
+
 ```bash
 npm install
 ```
 
-### 2. Variabel Lingkungan
-Salin file `.env.example` ke `.env` dan sesuaikan dengan konfigurasi Anda:
+### 2. Configure environment
+
+Copy the example file and fill in your own values:
+
 ```bash
 cp .env.example .env
 ```
 
-Edit file `.env` dengan konfigurasi R2 Anda:
 ```env
-# Server Configuration
+# Server
 PORT=3000
 NODE_ENV=development
 
-# Cloudflare R2 Configuration
+# Cloudflare R2
 R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
 R2_ACCESS_KEY_ID=your_access_key_id
 R2_SECRET_ACCESS_KEY=your_secret_access_key
 R2_BUCKET_NAME=your_bucket_name
 R2_PUBLIC_URL=https://your-public-bucket-url.r2.dev
 
-# Authentication Configuration
+# Authentication — CHANGE THESE BEFORE DEPLOYING
 ADMIN_USERNAME=admin
-ADMIN_PASSWORD=admin123
-ACCESS_TOKEN_SECRET=your-super-secret-access-token-key-change-this-in-production
-REFRESH_TOKEN_SECRET=your-super-secret-refresh-token-key-change-this-in-production
+ADMIN_PASSWORD=change-me
+ACCESS_TOKEN_SECRET=use-a-long-random-string-min-32-chars
+REFRESH_TOKEN_SECRET=use-a-different-long-random-string
 
-# API Configuration
-API_KEY=your-api-key-for-external-access-change-this
+# Public API
+API_KEY=generate-a-strong-random-api-key
 ```
 
-### 3. Jalankan aplikasi
+> **Security:** The default admin credentials are placeholders. Always set a strong password and unique 32+ character secrets before exposing the app. Never commit your `.env` file — it is gitignored by default.
 
-#### Untuk Development Lokal (tanpa Vercel CLI):
+### 3. Run
+
 ```bash
-# Development dengan auto-reload
+# Auto-reload (development)
 npm run dev
 
-# Atau jalankan biasa
+# Plain start
 npm start
 ```
 
-#### Untuk Testing dengan Vercel (jika sudah install Vercel CLI):
-```bash
-# Development dengan Vercel
-npm run vercel:dev
-
-# Deploy ke production
-npm run vercel:deploy
-```
-
-Aplikasi akan berjalan di:
-- **Local development**: `http://localhost:3000`
-- **Vercel development**: `http://localhost:3000` (atau port yang ditampilkan Vercel)
-
-## Deployment ke Vercel
-
-### Persiapan
-1. Pastikan semua file sudah menggunakan `module.exports` (bukan `export default`)
-2. Set environment variables di Vercel dashboard
-3. Pastikan `vercel.json` sudah dikonfigurasi dengan benar
-
-### Deploy
-```bash
-# Install Vercel CLI (opsional, bisa deploy via Git)
-npm i -g vercel
-
-# Deploy
-vercel --prod
-```
-
-Atau push ke Git repository yang sudah terhubung dengan Vercel untuk auto-deployment.
+The app runs at `http://localhost:3000` and redirects to the login page.
 
 ## Authentication
 
-### Default Credentials
-- **Username**: `admin`
-- **Password**: `admin123`
+The dashboard is protected by username/password login backed by JWT:
 
-### Security Features
-- JWT Access Token (15 menit)
-- JWT Refresh Token (7 hari)
-- HTTP-only cookies untuk keamanan
-- Automatic token refresh
-- Protected routes
+- Access token (short-lived) and refresh token (long-lived)
+- Tokens are delivered as HTTP-only cookies, never in the response body
+- Automatic token refresh and protected routes
+- Auto logout on session expiry
 
-### Login Process
-1. Akses `http://localhost:3000` (akan redirect ke login)
-2. Masukkan username dan password
-3. Setelah login berhasil, akan redirect ke dashboard file manager
+The public API uses a separate API key for machine-to-machine access.
 
-## API Endpoints
+## API Reference
 
-### Authentication Routes
+### Authentication routes
+
 ```
-POST /auth/login     - Login dengan username/password
-POST /auth/logout    - Logout dan clear cookies
-POST /auth/refresh   - Refresh access token (dengan refresh token di cookie)
-GET  /auth/status    - Check authentication status
+POST /auth/login     Log in with username/password
+POST /auth/logout    Log out and clear cookies
+POST /auth/refresh   Refresh the access token (uses refresh cookie)
+GET  /auth/status    Check authentication status
 ```
 
-### Internal (Frontend) File Routes (Requires JWT Auth via Cookie)
+### Internal file routes (require a JWT session cookie)
+
 ```
-POST   /r2/upload              - Upload file (via web UI)
-POST   /r2/upload-webp         - Upload & convert image to WebP (via web UI)
-GET    /r2/files               - List files with pagination (web UI)
-GET    /r2/download/:key       - Download file
-GET    /r2/presigned/:key      - Get temporary URL
-DELETE /r2/files/:key          - Delete file
+POST   /r2/upload          Upload a file (web UI)
+POST   /r2/upload-webp      Upload and convert an image to WebP (web UI)
+GET    /r2/files            List files with pagination
+GET    /r2/download/:key    Download a file
+GET    /r2/presigned/:key   Get a temporary (presigned) URL
+DELETE /r2/files/:key       Delete a file
 ```
 
-### Public API Routes (Requires API Key)
+### Public API routes (require an API key, or a JWT session where noted)
+
 ```
-POST   /api/upload             - Upload single file (API key)
-POST   /api/upload-multiple    - Upload multiple files (max 10, API key)
-POST   /api/files/upload       - Upload single file (API key atau JWT)
-POST   /api/files/upload-webp  - Upload image and convert to WebP (API key; juga mendukung JWT via cookie)
-GET    /api/files              - List files with pagination (API key atau JWT)
-DELETE /api/files/:key         - Delete file (API key atau JWT)
-GET    /api/stats/storage      - Get detailed storage statistics (API key atau JWT)
-GET    /api/stats/quick        - Get quick storage stats (API key atau JWT)
-GET    /api/apikey             - Return configured API key (PUBLIC for docs/dev; jangan aktifkan di production)
-GET    /api/info               - API information
+POST   /api/upload             Upload a single file (API key)
+POST   /api/upload-multiple    Upload up to 10 files (API key)
+POST   /api/files/upload       Upload a single file (API key or JWT)
+POST   /api/files/upload-webp  Upload and convert an image to WebP (API key or JWT)
+GET    /api/files              List files with pagination (API key or JWT)
+DELETE /api/files/:key         Delete a file (API key or JWT)
+GET    /api/stats/storage      Detailed storage statistics (API key or JWT)
+GET    /api/stats/quick        Quick storage stats (API key or JWT)
+GET    /api/info               API information
+GET    /api/apikey             Return the configured API key (admin JWT session only)
 ```
 
-## API Integration
+> **Note:** `GET /api/apikey` is intended only to populate the in-app API docs for a logged-in admin. It requires a valid JWT session and never responds to unauthenticated or cross-origin requests.
 
-### API Authentication
-API eksternal menggunakan API Key untuk autentikasi. Sertakan API key dalam header:
+### Using the API
+
+Pass the API key as a header — either form works:
 
 ```bash
-# Option 1: X-API-Key header
-curl -H "X-API-Key: your-api-key" \
-     -X POST \
-     http://localhost:3000/api/upload
+# X-API-Key header
+curl -H "X-API-Key: your-api-key" -X POST http://localhost:3000/api/upload
 
-# Option 2: Authorization Bearer
-curl -H "Authorization: Bearer your-api-key" \
-     -X POST \
-     http://localhost:3000/api/upload
+# Authorization Bearer
+curl -H "Authorization: Bearer your-api-key" -X POST http://localhost:3000/api/upload
 ```
 
-### Upload File via API
+Upload examples:
+
 ```bash
-# Single file upload
+# Single file
 curl -X POST \
   -H "X-API-Key: your-api-key" \
-  -F "file=@/path/to/your/file.jpg" \
+  -F "file=@/path/to/file.jpg" \
   http://localhost:3000/api/upload
 
-# Multiple files upload
+# Multiple files (max 10)
 curl -X POST \
   -H "X-API-Key: your-api-key" \
   -F "files=@/path/to/file1.jpg" \
   -F "files=@/path/to/file2.png" \
   http://localhost:3000/api/upload-multiple
 
-# Upload & convert to WebP (opsional param: quality [1-100], default 80)
+# Upload and convert to WebP (optional quality 1-100, default 80)
 curl -X POST \
   -H "X-API-Key: your-api-key" \
   -F "image=@/path/to/image.png" \
@@ -180,148 +165,78 @@ curl -X POST \
   http://localhost:3000/api/files/upload-webp
 ```
 
-### API Documentation
-Akses dokumentasi API lengkap di: `http://localhost:3000/api-docs.html` atau `http://localhost:3000/api-docs` (setelah login)
+Full interactive API docs are available at `/api-docs` after logging in.
 
-## Frontend Features
+## Frontend
 
-Frontend dapat diakses di `http://localhost:3000` dan menyediakan:
+Accessible at `http://localhost:3000`:
 
-### Dashboard File Manager (Internal, JWT Auth)
-- **Responsive Design**: Bekerja optimal di desktop dan mobile
-- **Drag & Drop Upload**: Upload multiple files sekaligus
-- **File Filtering**: Filter berdasarkan tipe file (gambar, dokumen, audio, video, archive)
-- **Search**: Pencarian file berdasarkan nama
-- **Pagination**: Load more untuk performa optimal
-- **Image Preview**: Preview gambar dengan zoom in/out
+- **File manager** — responsive dashboard with drag & drop, type filtering, search, pagination, and image preview
+- **WebP converter** — `/webp-converter` utility page
+- **Stats dashboard** — `/stats` capacity and file-count overview
+- **File operations** — copy public URL, generate temporary presigned URL (default 1 hour, override with `?expires=<seconds>`), download, and delete
 
-### Halaman Tambahan
-- **WebP Converter**: Halaman utilitas untuk konversi gambar ke WebP via UI di `/webp-converter` (backend: `POST /r2/upload-webp`)
-- **Stats Dashboard**: Ikhtisar kapasitas dan jumlah file di `/stats` (backend: `GET /api/stats/quick` dan `GET /api/stats/storage`)
+## Upload Limits
 
-### File Operations
-- **Public URL**: Copy direct link ke file
-- **Temporary URL**: Generate presigned URL (default 1 jam; dapat diubah dengan query `?expires=<detik>`, mis. 86400 untuk 24 jam)
-- **Download**: Download file langsung
-- **Delete**: Hapus file dengan konfirmasi
+- Internal web UI (`/r2/upload`): 25 MB per file by default
+- Serverless API (`/api/upload`, `/api/upload-multiple`): 4 MB per file (Vercel Hobby compatibility)
+- WebP endpoints accept an `image` field and an optional `quality` parameter (default 80)
 
-### Security UI
-- **Login Page**: Modern login interface
-- **Auto Logout**: Otomatis logout saat session expired
-- **Toast Notifications**: Feedback untuk semua operasi
+## Deployment
 
-## Struktur Aplikasi
-```
-file-service/
-├── .env.example              # Template konfigurasi
-├── package.json              # Dependencies
-├── README.md                 # Dokumentasi
-├── api/                      # Vercel serverless functions
-│   ├── utils.js              # Shared utilities
-│   ├── r2-client.js          # R2 client for serverless
-│   ├── auth.js               # Authentication endpoints handler (JWT login/refresh/logout/status)
-│   ├── r2.js                 # Internal file operations (JWT)
-│   ├── files.js              # API key/JWT file operations (list/delete/upload-webp)
-│   ├── upload.js             # API key upload (single)
-│   ├── upload-multiple.js    # API key upload multiple
-│   ├── stats.js              # Storage statistics endpoints (API key/JWT)
-│   ├── apikey.js             # Return configured API key (admin)
-│   └── info.js               # API info
-├── public/
-│   ├── index.html            # Main UI (file manager)
-│   ├── login.html            # Login page
-│   ├── webp-converter.html   # WebP converter UI
-│   ├── stats.html            # Stats dashboard UI
-│   └── api-docs.html         # API documentation
-└── vercel.json               # Vercel configuration
-```
+### Vercel
 
-## Security Notes
+1. Push the repository to GitHub.
+2. Import the project at [vercel.com](https://vercel.com).
+3. Set the environment variables (same keys as `.env`) in the Vercel dashboard.
+4. Deploy — Vercel builds the serverless functions in `api/` automatically.
 
-### Production Deployment
-1. **Change default credentials** di environment variables
-2. **Set strong JWT secrets** (minimal 32 karakter)
-3. **Enable HTTPS** untuk production
-4. **Set NODE_ENV=production**
-5. **Configure proper CORS origins**
+### Standalone Node
 
-### Environment Variables untuk Production
-```env
-NODE_ENV=production
-ADMIN_USERNAME=your_secure_username
-ADMIN_PASSWORD=your_strong_password
-ACCESS_TOKEN_SECRET=very-long-random-string-for-access-tokens
-REFRESH_TOKEN_SECRET=different-very-long-random-string-for-refresh-tokens
-```
-
-## Deployment ke Vercel
-
-### Langkah Deployment
-
-1. **Push ke GitHub repository**
-2. **Connect ke Vercel**:
-   - Login ke [vercel.com](https://vercel.com)
-   - Import project dari GitHub
-   - Pilih repository ini
-
-3. **Set Environment Variables di Vercel**:
-   ```
-   R2_ENDPOINT=https://your-account-id.r2.cloudflarestorage.com
-   R2_ACCESS_KEY_ID=your_access_key_id
-   R2_SECRET_ACCESS_KEY=your_secret_access_key
-   R2_BUCKET_NAME=your_bucket_name
-   R2_PUBLIC_URL=https://your-public-bucket-url.r2.dev
-   
-   ADMIN_USERNAME=admin
-   ADMIN_PASSWORD=your_secure_password
-   ACCESS_TOKEN_SECRET=your-super-secret-access-token-key
-   REFRESH_TOKEN_SECRET=your-super-secret-refresh-token-key
-   API_KEY=your-api-key-for-external-access
-   ```
-
-4. **Deploy**: Vercel akan otomatis deploy project
-
-### Struktur Serverless
-```
-file-service/
-├── api/                      # Vercel serverless functions
-│   ├── utils.js              # Shared utilities
-│   ├── r2-client.js          # R2 client for serverless
-│   ├── auth-middleware.js    # JWT middleware
-│   ├── auth-routes.js        # Authentication endpoints
-│   ├── r2.js                 # Internal file operations (JWT)
-│   ├── files.js              # API key file operations
-│   ├── upload.js             # API key upload
-│   ├── upload-multiple.js    # API key upload multiple
-│   └── info.js               # API info
-├── public/                   # Static files
-│   ├── index.html            # Main UI
-│   ├── login.html            # Login page
-│   └── api-docs.html         # API documentation
-└── vercel.json               # Vercel configuration
-```
-
-### Testing Local Development
 ```bash
-# Install Vercel CLI
-npm i -g vercel
-
-# Run local development server
-vercel dev
-
-# Access at http://localhost:3000
+NODE_ENV=production npm start
 ```
 
-## Teknologi yang Digunakan
-- **Backend**: Vercel Serverless Functions, JWT, bcryptjs
-- **Frontend**: Vanilla JavaScript, Tailwind CSS, Font Awesome
-- **Storage**: Cloudflare R2 (S3-compatible)
-- **Security**: HTTP-only cookies, CORS, JWT refresh mechanism
-- **Deployment**: Vercel (Full-stack serverless)
+Put it behind a reverse proxy (nginx, Caddy) with HTTPS enabled.
 
-## Catatan & Limitasi Upload
-- Endpoint internal (web UI) `/r2/upload` menggunakan limit ukuran default 25MB per file.
-- Endpoint API serverless `/api/upload` dan `/api/upload-multiple` menggunakan limit 4MB per file (kompatibilitas Vercel Hobby).
-- Endpoint konversi WebP:
-  - `/r2/upload-webp` (UI internal) menerima image dan mengonversi ke WebP dengan parameter opsional `quality` (default 80).
-  - `/api/files/upload-webp` (API) fungsionalitas setara, memerlukan field `image` dan opsional `quality`.
+### Production checklist
+
+- [ ] Change `ADMIN_USERNAME` / `ADMIN_PASSWORD`
+- [ ] Set strong, unique `ACCESS_TOKEN_SECRET` and `REFRESH_TOKEN_SECRET` (32+ chars)
+- [ ] Set a strong `API_KEY`
+- [ ] Set `NODE_ENV=production`
+- [ ] Serve over HTTPS and configure CORS origins for your domain
+
+## Project Structure
+
+```
+r2-storage-panel/
+├── api/                    # Serverless functions / Express handlers
+│   ├── utils.js            # Shared utilities (auth, CORS, responses)
+│   ├── r2-client.js        # R2 (S3-compatible) client
+│   ├── auth.js             # Auth endpoints (login/refresh/logout/status)
+│   ├── r2.js               # Internal file operations (JWT)
+│   ├── files.js            # API-key/JWT file operations
+│   ├── upload.js           # API-key single upload
+│   ├── upload-multiple.js  # API-key multiple upload
+│   ├── stats.js            # Storage statistics
+│   ├── apikey.js           # Return API key (admin JWT only)
+│   └── info.js             # API info
+├── public/                 # Static frontend
+│   ├── index.html          # File manager
+│   ├── login.html          # Login page
+│   ├── webp-converter.html # WebP converter UI
+│   ├── stats.html          # Stats dashboard
+│   └── api-docs.html       # API documentation
+├── server.js               # Express entry point (standalone)
+├── vercel.json             # Vercel configuration
+└── .env.example            # Environment template
+```
+
+## Contributing
+
+Contributions are welcome. Please read [CONTRIBUTING.md](CONTRIBUTING.md) and the [Code of Conduct](CODE_OF_CONDUCT.md) before opening a pull request. For security issues, see [SECURITY.md](SECURITY.md).
+
+## License
+
+Released under the [MIT License](LICENSE).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+# Security Policy
+
+## Supported Versions
+
+This project is under active development. Security fixes are applied to the
+latest released version on the `main` branch.
+
+## Reporting a Vulnerability
+
+Please **do not** open a public issue for security vulnerabilities.
+
+Instead, report it privately using GitHub's
+[private vulnerability reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability)
+("Report a vulnerability" under the repository's **Security** tab).
+
+When reporting, please include:
+
+- A description of the vulnerability and its impact
+- Steps to reproduce
+- Affected version or commit
+- Any suggested mitigation, if known
+
+You can expect an initial acknowledgement within 72 hours. Once the issue is
+confirmed, a fix will be prepared and a coordinated disclosure timeline agreed.
+
+## Security Best Practices for Operators
+
+This software handles file storage credentials and access tokens. When you
+deploy it:
+
+- **Change all default credentials** (`ADMIN_USERNAME`, `ADMIN_PASSWORD`).
+- **Use strong, unique secrets** for `ACCESS_TOKEN_SECRET` and
+  `REFRESH_TOKEN_SECRET` (32+ random characters each).
+- **Use a strong, random `API_KEY`** and rotate it if exposed.
+- **Never commit your `.env` file.** It is gitignored by default.
+- **Serve over HTTPS only** in production and set `NODE_ENV=production`.
+- **Restrict CORS origins** to the domains you control.
+- Treat R2 access keys as secrets and scope them to the minimum required
+  permissions.
+
+## Known Design Notes
+
+- Authentication tokens are stored in HTTP-only cookies, never in
+  `localStorage` or response bodies.
+- `GET /api/apikey` returns the configured API key only to an authenticated
+  admin session (valid JWT cookie). It must never be exposed publicly.

--- a/api/apikey.js
+++ b/api/apikey.js
@@ -1,18 +1,30 @@
 // Endpoint: /api/apikey
-// Mengembalikan API key dari environment (hanya untuk kebutuhan inject ke FE docs, bukan untuk konsumsi publik)
+// Returns the configured API key ONLY to an authenticated admin session (JWT).
+// This value is sensitive: it grants upload/delete access to the bucket.
+// It must never be exposed publicly or with a wildcard CORS policy.
+
+const { authenticateToken, handleCors, errorResponse } = require('./utils');
 
 module.exports = async (req, res) => {
+  // Credentialed CORS (reflects request origin, allows cookies). Never wildcard.
+  if (handleCors(req, res)) return;
+
   if (req.method !== 'GET') {
     res.setHeader('Allow', 'GET');
-    return res.status(405).json({ error: 'Method Not Allowed' });
+    return errorResponse(res, 405, 'Method Not Allowed');
   }
-  // CORS agar bisa diakses dari mana saja (khusus endpoint ini)
-  res.setHeader('Access-Control-Allow-Origin', '*');
-  res.setHeader('Access-Control-Allow-Methods', 'GET, OPTIONS');
-  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
-  if (req.method === 'OPTIONS') return res.status(200).end();
+
+  // Require a valid admin session. Without this, the API key would leak.
+  try {
+    authenticateToken(req);
+  } catch (err) {
+    return errorResponse(res, 401, 'Unauthorized', 'Valid admin session required');
+  }
 
   const apiKey = process.env.API_KEY || '';
-  if (!apiKey) return res.status(404).json({ error: 'API key not set' });
-  res.json({ apiKey });
+  if (!apiKey) {
+    return errorResponse(res, 404, 'API key not configured');
+  }
+
+  return res.status(200).json({ apiKey });
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "file-service",
+  "name": "r2-storage-panel",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "file-service",
+      "name": "r2-storage-panel",
       "version": "1.0.0",
+      "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.837.0",
         "@aws-sdk/s3-request-presigner": "^3.837.0",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,30 @@
 {
-  "name": "file-service",
+  "name": "r2-storage-panel",
   "version": "1.0.0",
-  "description": "R2 File Manager with Vercel deployment support",
+  "description": "Self-hostable Cloudflare R2 file manager with JWT auth, an API-key protected public API, and a Tailwind UI.",
   "main": "server.js",
+  "license": "MIT",
+  "author": "Soim Alfath",
+  "homepage": "https://github.com/soimalfath/r2-storage-panel#readme",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/soimalfath/r2-storage-panel.git"
+  },
+  "bugs": {
+    "url": "https://github.com/soimalfath/r2-storage-panel/issues"
+  },
+  "keywords": [
+    "cloudflare-r2",
+    "r2",
+    "s3",
+    "file-manager",
+    "file-upload",
+    "express",
+    "vercel"
+  ],
   "scripts": {
     "start": "node server.js",
     "dev": "nodemon server.js",
-    "test": "node test-server.js",
     "build": "echo 'No build step required'",
     "vercel:dev": "vercel dev",
     "vercel:deploy": "vercel --prod"

--- a/public/js/api-docs.js
+++ b/public/js/api-docs.js
@@ -79,13 +79,13 @@ document.addEventListener('DOMContentLoaded', () => {
     // Configuration
     // Ambil API_KEY dari endpoint backend agar selalu sinkron dengan env
     let DEFAULT_API_KEY = 'your-api-key-change-this';
-    fetch('/api/apikey')
+    fetch('/api/apikey', { credentials: 'include' })
       .then(r => r.json())
       .then(d => {
         if (d.apiKey) DEFAULT_API_KEY = d.apiKey;
-        else showToast('Gagal mengambil API key dari backend', 'error');
+        else showToast('Failed to load API key from backend', 'error');
       })
-     .catch(() => showToast('Gagal mengambil API key dari backend', 'error'));
+     .catch(() => showToast('Failed to load API key from backend', 'error'));
 
     // DOM Elements
     const generateApiKeyBtn = document.getElementById('generateApiKeyBtn');
@@ -166,7 +166,7 @@ document.addEventListener('DOMContentLoaded', () => {
             apiKeySection.classList.remove('hidden');
             // Ambil API key terbaru dari backend jika belum ada
             if (!DEFAULT_API_KEY || DEFAULT_API_KEY === 'your-api-key-change-this') {
-                fetch('/api/apikey').then(r => r.json()).then(d => {
+                fetch('/api/apikey', { credentials: 'include' }).then(r => r.json()).then(d => {
                     apiKeyDisplay.value = d.apiKey || 'your-api-key-change-this';
                 });
             } else {


### PR DESCRIPTION
## Summary

Patches a live credential-leak and prepares the repo for public open-source use.

### 🔴 Security fix
- `GET /api/apikey` previously returned `API_KEY` to **any** caller with a wildcard CORS policy and no authentication. On a deployed instance this leaks upload/delete access to the R2 bucket.
- Now requires a valid admin JWT session; responds **401** otherwise. The in-app API docs fetches were updated to send credentials so the logged-in admin flow still works.

### 📄 Open-source files
- MIT `LICENSE`
- English `README` (accurate endpoints; default credentials reframed as a 'change before deploy' warning)
- `SECURITY.md`, `CONTRIBUTING.md`, `CODE_OF_CONDUCT.md`
- GitHub issue + PR templates under `.github/`

### 🔧 Metadata
- `package.json` renamed `file-service` → `r2-storage-panel`; added license/repo/bugs/keywords
- Removed broken `test` script (referenced a nonexistent `test-server.js`)

## Testing
- `npm install` clean (251 packages)
- Booted server: `GET /api/apikey` returns **401** unauthenticated; `/login` returns **200**
- `node --check` on changed JS, `package.json` validates as JSON